### PR TITLE
Inverse Probability of Censoring Weighting

### DIFF
--- a/src/counterfactual_mean_based/clever_covariate.jl
+++ b/src/counterfactual_mean_based/clever_covariate.jl
@@ -18,7 +18,7 @@ function truncate!(v::AbstractVector, ps_lowerbound::AbstractFloat)
     end
 end
 
-function balancing_weights(G, dataset; ps_lowerbound=1e-8)
+function balancing_weights(G::JointConditionalDistributionEstimate, dataset; ps_lowerbound=1e-8)
     jointlikelihood = ones(nrows(dataset))
     for Gᵢ ∈ G.components
         jointlikelihood .*= likelihood(Gᵢ, dataset)

--- a/src/counterfactual_mean_based/clever_covariate.jl
+++ b/src/counterfactual_mean_based/clever_covariate.jl
@@ -33,6 +33,7 @@ end
         Gs::Tuple{Vararg{ConditionalDistributionEstimate}}, 
         dataset; 
         ps_lowerbound=1e-8, 
+        censoring_score=nothing,
         weighted_fluctuation=false
     )
 
@@ -54,6 +55,7 @@ function clever_covariate_and_weights(
     Ψ::StatisticalCMCompositeEstimand, 
     G, 
     dataset; 
+    censoring_score=nothing,
     ps_lowerbound=1e-8, 
     weighted_fluctuation=false
     )
@@ -61,6 +63,8 @@ function clever_covariate_and_weights(
     T = selectcols(dataset, (p.estimand.outcome for p in G.components))
     indic_vals = indicator_values(indicator_fns(Ψ), T)
     weights = balancing_weights(G, dataset; ps_lowerbound=ps_lowerbound)
+    ipcw = compute_ipcw_weights(censoring_score, dataset; ps_lowerbound=ps_lowerbound)
+    ipcw != nothing && (weights .*= ipcw)
     if weighted_fluctuation
         return indic_vals, weights
     end

--- a/src/counterfactual_mean_based/estimands.jl
+++ b/src/counterfactual_mean_based/estimands.jl
@@ -152,30 +152,11 @@ end
 
 propensity_score_key(Ψ::StatisticalCMCompositeEstimand) = Tuple(variables(x) for x ∈ propensity_score(Ψ))
 
-"""
-    get_relevant_factors(Ψ; collaborative_strategy=nothing, dataset=nothing)
-
-Returns the `CMRelevantFactors` needed to estimate `Ψ`: an outcome mean, propensity score(s),
-and optionally a censoring score for IPCW.
-
-## IPCW for missing outcomes
-
-When `dataset` is provided and the outcome column contains missing values, a censoring score
-model is automatically included. This enables Inverse Probability of Censoring Weighting (IPCW)
-to correct for outcome missingness under a Missing at Random (MAR) assumption.
-
-The censoring model `P(Δ=1 | parents)` is a binary classifier predicting whether the outcome
-is observed (Δ=1) or missing (Δ=0). Its parents are set to the same variables as the outcome
-mean model (treatments + confounders + extra covariates). This is a conservative default that
-conditions on all available covariates; it does not derive the censoring parents from an SCM
-or causal graph. The censoring mechanism is treated as a statistical nuisance, not a structural
-feature of the causal model.
-"""
-function get_relevant_factors(Ψ::StatisticalCMCompositeEstimand; collaborative_strategy=nothing, dataset=nothing)
+function get_relevant_factors(Ψ::StatisticalCMCompositeEstimand; collaborative_strategy=nothing, ipcw=false)
     outcome_model = outcome_mean(Ψ)
     treatment_factors = propensity_score(Ψ, collaborative_strategy)
     censoring_factor = nothing
-    if dataset !== nothing && has_missing_outcomes(dataset, Ψ.outcome)
+    if ipcw
         censoring_outcome = censoring_indicator_name(Ψ.outcome)
         censoring_parents = outcome_model.parents
         censoring_factor = ConditionalDistribution(censoring_outcome, censoring_parents)

--- a/src/counterfactual_mean_based/estimands.jl
+++ b/src/counterfactual_mean_based/estimands.jl
@@ -9,21 +9,38 @@ Counterfactual Mean composite estimand (see `StatisticalCMCompositeEstimand`).
 @auto_hash_equals struct CMRelevantFactors <: Estimand
     outcome_mean::ConditionalDistribution
     propensity_score::Tuple{Vararg{ConditionalDistribution}}
+    censoring_score::Union{Nothing, ConditionalDistribution}
 end
 
-CMRelevantFactors(outcome_mean, propensity_score::ConditionalDistribution) = 
-    CMRelevantFactors(outcome_mean, (propensity_score,))
 
-CMRelevantFactors(;outcome_mean, propensity_score) = 
-    CMRelevantFactors(outcome_mean, propensity_score)
+CMRelevantFactors(outcome_mean, propensity_score::ConditionalDistribution, censoring_score::Union{Nothing, ConditionalDistribution}=nothing) =
+    CMRelevantFactors(outcome_mean, (propensity_score,), censoring_score)
 
-string_repr(estimand::CMRelevantFactors) = 
-    string("Relevant Factors: \n- ",
-        string_repr(estimand.outcome_mean),"\n- ", 
-        join((string_repr(f) for f in estimand.propensity_score), "\n- "))
+CMRelevantFactors(;outcome_mean, propensity_score, censoring_score=nothing) =
+    CMRelevantFactors(outcome_mean, propensity_score, censoring_score)
 
-variables(estimand::CMRelevantFactors) = 
-    Tuple(union(variables(estimand.outcome_mean), (variables(est) for est in estimand.propensity_score)...))
+CMRelevantFactors(outcome_mean, propensity_score) =
+    CMRelevantFactors(outcome_mean, propensity_score, nothing)
+
+function string_repr(estimand::CMRelevantFactors)
+    parts = [
+        "Relevant Factors: \n- ",
+        string_repr(estimand.outcome_mean), "\n- ",
+        join((string_repr(f) for f in estimand.propensity_score), "\n- ")
+    ]
+    if estimand.censoring_score !== nothing
+        push!(parts, "\n- ", string_repr(estimand.censoring_score))
+    end
+    return string(parts...)
+end
+
+function variables(estimand::CMRelevantFactors)
+    vars = union(variables(estimand.outcome_mean), (variables(est) for est in estimand.propensity_score)...)
+    if estimand.censoring_score !== nothing
+        vars = union(vars, variables(estimand.censoring_score))
+    end
+    return Tuple(vars)
+end
 
 #####################################################################
 ###                         Functionals                           ###
@@ -135,10 +152,35 @@ end
 
 propensity_score_key(Ψ::StatisticalCMCompositeEstimand) = Tuple(variables(x) for x ∈ propensity_score(Ψ))
 
-function get_relevant_factors(Ψ::StatisticalCMCompositeEstimand; collaborative_strategy=nothing)
+"""
+    get_relevant_factors(Ψ; collaborative_strategy=nothing, dataset=nothing)
+
+Returns the `CMRelevantFactors` needed to estimate `Ψ`: an outcome mean, propensity score(s),
+and optionally a censoring score for IPCW.
+
+## IPCW for missing outcomes
+
+When `dataset` is provided and the outcome column contains missing values, a censoring score
+model is automatically included. This enables Inverse Probability of Censoring Weighting (IPCW)
+to correct for outcome missingness under a Missing at Random (MAR) assumption.
+
+The censoring model `P(Δ=1 | parents)` is a binary classifier predicting whether the outcome
+is observed (Δ=1) or missing (Δ=0). Its parents are set to the same variables as the outcome
+mean model (treatments + confounders + extra covariates). This is a conservative default that
+conditions on all available covariates; it does not derive the censoring parents from an SCM
+or causal graph. The censoring mechanism is treated as a statistical nuisance, not a structural
+feature of the causal model.
+"""
+function get_relevant_factors(Ψ::StatisticalCMCompositeEstimand; collaborative_strategy=nothing, dataset=nothing)
     outcome_model = outcome_mean(Ψ)
     treatment_factors = propensity_score(Ψ, collaborative_strategy)
-    return CMRelevantFactors(outcome_model, treatment_factors)
+    censoring_factor = nothing
+    if dataset !== nothing && has_missing_outcomes(dataset, Ψ.outcome)
+        censoring_outcome = censoring_indicator_name(Ψ.outcome)
+        censoring_parents = outcome_model.parents
+        censoring_factor = ConditionalDistribution(censoring_outcome, censoring_parents)
+    end
+    return CMRelevantFactors(outcome_model, treatment_factors, censoring_factor)
 end
 
 n_uniques_nuisance_functions(Ψ::StatisticalCMCompositeEstimand) = length(propensity_score(Ψ)) + 1

--- a/src/counterfactual_mean_based/estimates.jl
+++ b/src/counterfactual_mean_based/estimates.jl
@@ -9,7 +9,7 @@ for counterfactual mean based estimands' relevant factors.
 struct MLCMRelevantFactors <: Estimate
     estimand::CMRelevantFactors
     outcome_mean::ConditionalDistributionEstimate
-    propensity_score
+    propensity_score:: JointConditionalDistributionEstimate
     censoring_score::Union{Nothing, ConditionalDistributionEstimate}
 end
 

--- a/src/counterfactual_mean_based/estimates.jl
+++ b/src/counterfactual_mean_based/estimates.jl
@@ -16,6 +16,19 @@ end
 MLCMRelevantFactors(estimand, outcome_mean, propensity_score) =
     MLCMRelevantFactors(estimand, outcome_mean, propensity_score, nothing)
 
+"""
+    align_to_rows(factors::MLCMRelevantFactors, keep::Vector{Int})
+
+Realign every nuisance's CV fold indices from the full initial-dataset row space to the
+covariate-complete fluctuation subset (see `align_to_rows` on the component estimates).
+"""
+align_to_rows(factors::MLCMRelevantFactors, keep) = MLCMRelevantFactors(
+    factors.estimand,
+    align_to_rows(factors.outcome_mean, keep),
+    align_to_rows(factors.propensity_score, keep),
+    factors.censoring_score === nothing ? nothing : align_to_rows(factors.censoring_score, keep)
+)
+
 function string_repr(estimate::MLCMRelevantFactors)
     parts = [
         "Composite Factor Estimate: \n",

--- a/src/counterfactual_mean_based/estimates.jl
+++ b/src/counterfactual_mean_based/estimates.jl
@@ -10,14 +10,24 @@ struct MLCMRelevantFactors <: Estimate
     estimand::CMRelevantFactors
     outcome_mean::ConditionalDistributionEstimate
     propensity_score
+    censoring_score::Union{Nothing, ConditionalDistributionEstimate}
 end
 
-string_repr(estimate::MLCMRelevantFactors) = string(
-    "Composite Factor Estimate: \n",
-    "-------------------------\n- ",
-    string_repr(estimate.outcome_mean),"\n- ", 
-    join((string_repr(f) for f in estimate.propensity_score.components), "\n- ")
-)
+MLCMRelevantFactors(estimand, outcome_mean, propensity_score) =
+    MLCMRelevantFactors(estimand, outcome_mean, propensity_score, nothing)
+
+function string_repr(estimate::MLCMRelevantFactors)
+    parts = [
+        "Composite Factor Estimate: \n",
+        "-------------------------\n- ",
+        string_repr(estimate.outcome_mean), "\n- ",
+        join((string_repr(f) for f in estimate.propensity_score.components), "\n- ")
+    ]
+    if estimate.censoring_score !== nothing
+        push!(parts, "\n- ", string_repr(estimate.censoring_score))
+    end
+    return string(parts...)
+end
 
 #####################################################################
 ###                       FoldsMLCMRelevantFactors                     ###

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -118,13 +118,10 @@ function Tmle(;
 end
 
 function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
-    # Detect missing outcomes and guard unsupported IPCW combinations early
+    # Detect missing outcomes
     ipcw = has_missing_outcomes(dataset, Ψ.outcome)
-    if ipcw && tmle.resampling !== nothing
-        throw(ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla TMLE (resampling=nothing) instead."))
-    end
     if ipcw && tmle.prevalence !== nothing
-        throw(ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction."))
+        throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
     end
     # Check if the inputs are suitable for the specified estimand
     check_inputs(Ψ, dataset, tmle.prevalence)
@@ -132,18 +129,22 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     if ipcw
         add_censoring_indicator!(dataset, Ψ.outcome)
     end
-    # Make train-validation pairs
-    train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, dataset)
     # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
     relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy, dataset=ipcw ? dataset : nothing)
-    evaluation_dataset = get_evaluation_dataset(dataset, relevant_factors;
-        prevalence=tmle.prevalence,
+    fluctuation_dataset = get_fluctuation_dataset(dataset, relevant_factors;
+        prevalence=tmle.prevalence, 
         verbosity=verbosity
     )
+    # Make train-validation pairs from the evaluation dataset so fold indices align
+    train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, fluctuation_dataset)
 
-    # Nuisance fitting: original dataset in vanilla mode (each estimator filters internally),
-    # evaluation dataset in CV/prevalence mode (for fold index consistency / matched controls)
-    fitting_dataset = (train_validation_indices !== nothing || tmle.prevalence !== nothing) ? evaluation_dataset : dataset
+    fitting_dataset = if ipcw
+        get_fitting_dataset(dataset, relevant_factors)
+    elseif train_validation_indices !== nothing || tmle.prevalence !== nothing
+        fluctuation_dataset
+    else
+        dataset
+    end
 
     prevalence_weights = compute_prevalence_weights(tmle.prevalence, fitting_dataset[!, relevant_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy;
@@ -154,22 +155,22 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     verbosity >= 1 && @info "Estimating nuisance parameters."
 
     initial_factors_estimate = initial_factors_estimator(relevant_factors, fitting_dataset;
-        cache=cache,
+        cache=cache, 
         verbosity=verbosity-1,
         machine_cache=tmle.machine_cache,
         acceleration=acceleration
     )
     # Get propensity score truncation threshold
-    n = nrows(evaluation_dataset)
+    n = nrows(fluctuation_dataset)
     ps_lowerbound = ps_lower_bound(n, tmle.ps_lowerbound)
 
     # Compute IPCW weights if needed
-    ipcw_weights = compute_ipcw_weights(initial_factors_estimate, evaluation_dataset; ps_lowerbound=ps_lowerbound)
+    ipcw_weights = compute_ipcw_weights(initial_factors_estimate, fluctuation_dataset; ps_lowerbound=ps_lowerbound)
 
     # Fluctuation initial factors
     targeted_factors_estimator = get_targeted_estimator(
-        Ψ,
-        tmle.collaborative_strategy,
+        Ψ, 
+        tmle.collaborative_strategy, 
         train_validation_indices,
         initial_factors_estimate;
         tol=tmle.tol,
@@ -181,8 +182,8 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
         prevalence_weights=prevalence_weights,
         ipcw_weights=ipcw_weights
     )
-    targeted_factors_estimate = targeted_factors_estimator(relevant_factors, evaluation_dataset;
-        cache=cache,
+    targeted_factors_estimate = targeted_factors_estimator(relevant_factors, fluctuation_dataset; 
+        cache=cache, 
         verbosity=verbosity,
         machine_cache=tmle.machine_cache,
         acceleration=acceleration
@@ -258,13 +259,10 @@ Ose(;models=default_models(), resampling=nothing, ps_lowerbound=1e-8, machine_ca
     Ose(models, resampling, ps_lowerbound, machine_cache, prevalence)
 
 function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
-    # Detect missing outcomes and guard unsupported IPCW combinations early
+    # Detect missing outcomes
     ipcw = has_missing_outcomes(dataset, Ψ.outcome)
-    if ipcw && ose.resampling !== nothing
-        throw(ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla OSE (resampling=nothing) instead."))
-    end
     if ipcw && ose.prevalence !== nothing
-        throw(ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction."))
+        throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
     end
     # Check the estimand against the dataset
     check_inputs(Ψ, dataset, ose.prevalence)
@@ -272,18 +270,22 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     if ipcw
         add_censoring_indicator!(dataset, Ψ.outcome)
     end
-    # Make train-validation pairs
-    train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, dataset)
     # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
     initial_factors = get_relevant_factors(Ψ; dataset=ipcw ? dataset : nothing)
-    evaluation_dataset = get_evaluation_dataset(dataset, initial_factors;
+    fluctuation_dataset = get_fluctuation_dataset(dataset, initial_factors;
         prevalence=ose.prevalence,
         verbosity=verbosity
     )
+    # Make train-validation pairs from the evaluation dataset so fold indices align
+    train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, fluctuation_dataset)
 
-    # Nuisance fitting: original dataset in vanilla mode (each estimator filters internally),
-    # evaluation dataset in CV/prevalence mode (for fold index consistency / matched controls)
-    fitting_dataset = (train_validation_indices !== nothing || ose.prevalence !== nothing) ? evaluation_dataset : dataset
+    fitting_dataset = if ipcw
+        get_fitting_dataset(dataset, initial_factors)
+    elseif train_validation_indices !== nothing || ose.prevalence !== nothing
+        fluctuation_dataset
+    else
+        dataset
+    end
 
     prevalence_weights = compute_prevalence_weights(ose.prevalence, fitting_dataset[!, initial_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(;models=ose.models, train_validation_indices=train_validation_indices, prevalence_weights=prevalence_weights)
@@ -295,11 +297,11 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
         acceleration=acceleration
     )
     # Get propensity score truncation threshold
-    n = nrows(evaluation_dataset)
+    n = nrows(fluctuation_dataset)
     ps_lowerbound = ps_lower_bound(n, ose.ps_lowerbound)
 
     # Gradient and estimate
-    IC, Ψ̂ = gradient_and_estimate(ose, Ψ, initial_factors_estimate, evaluation_dataset, prevalence_weights; ps_lowerbound=ps_lowerbound)
+    IC, Ψ̂ = gradient_and_estimate(ose, Ψ, initial_factors_estimate, fluctuation_dataset, prevalence_weights; ps_lowerbound=ps_lowerbound)
     σ̂ = std(IC)
     n = size(IC, 1)
     verbosity >= 1 && @info "Done."

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -138,17 +138,15 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     # Make train-validation pairs from the evaluation dataset so fold indices align
     train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, fluctuation_dataset)
 
-    fitting_dataset = if ipcw
-        get_fitting_dataset(dataset, relevant_factors)
-    elseif train_validation_indices !== nothing || tmle.prevalence !== nothing
+    fitting_dataset = if train_validation_indices !== nothing || tmle.prevalence !== nothing || ipcw
         fluctuation_dataset
     else
         dataset
     end
 
     prevalence_weights = compute_prevalence_weights(tmle.prevalence, fitting_dataset[!, relevant_factors.outcome_mean.outcome])
-    initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy;
-        train_validation_indices=train_validation_indices,
+    initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy; 
+        train_validation_indices=train_validation_indices, 
         models=tmle.models,
         prevalence_weights=prevalence_weights
     )
@@ -279,9 +277,7 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     # Make train-validation pairs from the evaluation dataset so fold indices align
     train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, fluctuation_dataset)
 
-    fitting_dataset = if ipcw
-        get_fitting_dataset(dataset, initial_factors)
-    elseif train_validation_indices !== nothing || ose.prevalence !== nothing
+    fitting_dataset = if train_validation_indices !== nothing || ose.prevalence !== nothing || ipcw
         fluctuation_dataset
     else
         dataset

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -126,11 +126,9 @@ end
 function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
     # Detect missing outcomes
     ipcw = tmle.ipcw & has_missing_outcomes(dataset, Ψ.outcome)
-    if ipcw && tmle.prevalence !== nothing
-        throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
-    end
+
     # Check if the inputs are suitable for the specified estimand
-    check_inputs(Ψ, dataset, tmle.prevalence)
+    check_inputs(Ψ, dataset, tmle.prevalence, ipcw)
     # Add censoring indicator if needed
     if ipcw
         dataset = add_censoring_indicator(dataset, Ψ.outcome)
@@ -264,7 +262,7 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
         throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
     end
     # Check the estimand against the dataset
-    check_inputs(Ψ, dataset, ose.prevalence)
+    check_inputs(Ψ, dataset, ose.prevalence, ipcw)
     # Add censoring indicator if needed
     if ipcw
         dataset = add_censoring_indicator(dataset, Ψ.outcome)

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -59,7 +59,24 @@ been show to be more robust to positivity violation in practice.
 - tol (default: nothing): Convergence threshold for the TMLE algorithm iterations. If nothing (default), 1/(sample size) will be used. See also `max_iter`.
 - max_iter (default: 1): Maximum number of iterations for the TMLE algorithm.
 - machine_cache (default: false): Whether MLJ.machine created during estimation should cache data.
-- prevalence (default: nothing): If provided, the prevalence weights will be used to weight the observations to match the true prevalence of the source population. 
+- prevalence (default: nothing): If provided, the prevalence weights will be used to weight the observations to match the true prevalence of the source population.
+
+# Missing outcomes (IPCW)
+
+When the outcome column contains `missing` values, Inverse Probability of Censoring Weighting
+(IPCW) is automatically applied. A binary censoring model `π(W) = P(Δ=1 | W)` is fit to predict
+whether the outcome is observed, and the efficient influence curve is reweighted by `Δ/π` to
+correct for outcome missingness. This is valid under a Missing at Random (MAR) assumption — i.e.
+the probability of observing the outcome may depend on treatments and covariates, but not on the
+(unobserved) outcome value itself.
+
+The censoring model's covariates default to the same parents as the outcome mean model. To use a
+custom censoring model, pass it via the `models` dict under the key `:C_default` or under the
+censoring indicator name (e.g. `Symbol("Δ_Y")`). See also `default_models`.
+
+The outcome mean (Q) is always fit on complete cases only, while the propensity score (G) and
+censoring model (π) are fit on all observations. The influence curve and plugin estimate are
+evaluated on all observations with non-missing covariates.
 
 # Run Argument
 
@@ -103,10 +120,15 @@ end
 function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
     # Check if the inputs are suitable for the specified estimand
     check_inputs(Ψ, dataset, tmle.prevalence)
+    # Detect missing outcomes and add censoring indicator if needed
+    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    if ipcw
+        add_censoring_indicator!(dataset, Ψ.outcome)
+    end
     # Make train-validation pairs
     train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, dataset)
-    # Initial fit of the SCM's relevant factors
-    relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy)
+    # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
+    relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy, dataset=ipcw ? dataset : nothing)
     fluctuation_dataset = get_fluctuation_dataset(dataset, relevant_factors;
         prevalence=tmle.prevalence, 
         verbosity=verbosity
@@ -135,6 +157,9 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     n = nrows(fluctuation_dataset)
     ps_lowerbound = ps_lower_bound(n, tmle.ps_lowerbound)
 
+    # Compute IPCW weights if needed
+    ipcw_weights = compute_ipcw_weights(initial_factors_estimate, fluctuation_dataset; ps_lowerbound=ps_lowerbound)
+
     # Fluctuation initial factors
     targeted_factors_estimator = get_targeted_estimator(
         Ψ, 
@@ -147,7 +172,8 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
         weighted=tmle.weighted,
         machine_cache=tmle.machine_cache,
         models=tmle.models,
-        prevalence_weights=prevalence_weights
+        prevalence_weights=prevalence_weights,
+        ipcw_weights=ipcw_weights
     )
     targeted_factors_estimate = targeted_factors_estimator(relevant_factors, fluctuation_dataset; 
         cache=cache, 
@@ -198,6 +224,13 @@ result in a data adaptive definition as described in [here](https://pubmed.ncbi.
 - machine_cache: Whether MLJ.machine created during estimation should cache data.
 - prevalence: The prevalence of the outcome in the population. If provided, the estimator will use case control 
 weights to correct for biased sampling.
+
+# Missing outcomes (IPCW)
+
+When the outcome column contains `missing` values, Inverse Probability of Censoring Weighting
+(IPCW) is automatically applied. See the `Tmle` docstring for details on the IPCW mechanism,
+modeling assumptions, and how to customize the censoring model.
+
 # Run Argument
 
 - Ψ: parameter of interest
@@ -221,10 +254,15 @@ Ose(;models=default_models(), resampling=nothing, ps_lowerbound=1e-8, machine_ca
 function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
     # Check the estimand against the dataset
     check_inputs(Ψ, dataset, ose.prevalence)
+    # Detect missing outcomes and add censoring indicator if needed
+    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    if ipcw
+        add_censoring_indicator!(dataset, Ψ.outcome)
+    end
     # Make train-validation pairs
     train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, dataset)
-    # Initial fit of the SCM's relevant factors
-    initial_factors = get_relevant_factors(Ψ)
+    # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
+    initial_factors = get_relevant_factors(Ψ; dataset=ipcw ? dataset : nothing)
     fluctuation_dataset = get_fluctuation_dataset(dataset, initial_factors;
         prevalence=ose.prevalence,
         verbosity=verbosity
@@ -265,7 +303,7 @@ function gradient_and_estimate(::Ose, Ψ, factors, dataset, prevalence_weights; 
     Q = factors.outcome_mean
     G = factors.propensity_score
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
-    gradient_Y_X = ∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound)
+    gradient_Y_X = ∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound, censoring_score=factors.censoring_score)
     y = float(dataset[!, Q.estimand.outcome])
     IC, Ψ̂ = gradient_and_estimate(ctf_agg, gradient_Y_X, y, prevalence_weights)
     IC_mean = mean(IC)

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -118,10 +118,17 @@ function Tmle(;
 end
 
 function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
+    # Detect missing outcomes and guard unsupported IPCW combinations early
+    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    if ipcw && tmle.resampling !== nothing
+        throw(ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla TMLE (resampling=nothing) instead."))
+    end
+    if ipcw && tmle.prevalence !== nothing
+        throw(ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction."))
+    end
     # Check if the inputs are suitable for the specified estimand
     check_inputs(Ψ, dataset, tmle.prevalence)
-    # Detect missing outcomes and add censoring indicator if needed
-    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    # Add censoring indicator if needed
     if ipcw
         add_censoring_indicator!(dataset, Ψ.outcome)
     end
@@ -129,41 +136,40 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, dataset)
     # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
     relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy, dataset=ipcw ? dataset : nothing)
-    fluctuation_dataset = get_fluctuation_dataset(dataset, relevant_factors;
-        prevalence=tmle.prevalence, 
+    evaluation_dataset = get_evaluation_dataset(dataset, relevant_factors;
+        prevalence=tmle.prevalence,
         verbosity=verbosity
     )
 
-    initial_factors_dataset = choose_initial_dataset(dataset, fluctuation_dataset; 
-        train_validation_indices=train_validation_indices, 
-        prevalence=tmle.prevalence
-    )
+    # Nuisance fitting: original dataset in vanilla mode (each estimator filters internally),
+    # evaluation dataset in CV/prevalence mode (for fold index consistency / matched controls)
+    fitting_dataset = (train_validation_indices !== nothing || tmle.prevalence !== nothing) ? evaluation_dataset : dataset
 
-    prevalence_weights = compute_prevalence_weights(tmle.prevalence, initial_factors_dataset[!, relevant_factors.outcome_mean.outcome])
-    initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy; 
-        train_validation_indices=train_validation_indices, 
+    prevalence_weights = compute_prevalence_weights(tmle.prevalence, fitting_dataset[!, relevant_factors.outcome_mean.outcome])
+    initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy;
+        train_validation_indices=train_validation_indices,
         models=tmle.models,
         prevalence_weights=prevalence_weights
     )
     verbosity >= 1 && @info "Estimating nuisance parameters."
-    
-    initial_factors_estimate = initial_factors_estimator(relevant_factors, initial_factors_dataset; 
-        cache=cache, 
+
+    initial_factors_estimate = initial_factors_estimator(relevant_factors, fitting_dataset;
+        cache=cache,
         verbosity=verbosity-1,
         machine_cache=tmle.machine_cache,
         acceleration=acceleration
     )
     # Get propensity score truncation threshold
-    n = nrows(fluctuation_dataset)
+    n = nrows(evaluation_dataset)
     ps_lowerbound = ps_lower_bound(n, tmle.ps_lowerbound)
 
     # Compute IPCW weights if needed
-    ipcw_weights = compute_ipcw_weights(initial_factors_estimate, fluctuation_dataset; ps_lowerbound=ps_lowerbound)
+    ipcw_weights = compute_ipcw_weights(initial_factors_estimate, evaluation_dataset; ps_lowerbound=ps_lowerbound)
 
     # Fluctuation initial factors
     targeted_factors_estimator = get_targeted_estimator(
-        Ψ, 
-        tmle.collaborative_strategy, 
+        Ψ,
+        tmle.collaborative_strategy,
         train_validation_indices,
         initial_factors_estimate;
         tol=tmle.tol,
@@ -175,8 +181,8 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
         prevalence_weights=prevalence_weights,
         ipcw_weights=ipcw_weights
     )
-    targeted_factors_estimate = targeted_factors_estimator(relevant_factors, fluctuation_dataset; 
-        cache=cache, 
+    targeted_factors_estimate = targeted_factors_estimator(relevant_factors, evaluation_dataset;
+        cache=cache,
         verbosity=verbosity,
         machine_cache=tmle.machine_cache,
         acceleration=acceleration
@@ -252,10 +258,17 @@ Ose(;models=default_models(), resampling=nothing, ps_lowerbound=1e-8, machine_ca
     Ose(models, resampling, ps_lowerbound, machine_cache, prevalence)
 
 function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
+    # Detect missing outcomes and guard unsupported IPCW combinations early
+    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    if ipcw && ose.resampling !== nothing
+        throw(ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla OSE (resampling=nothing) instead."))
+    end
+    if ipcw && ose.prevalence !== nothing
+        throw(ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction."))
+    end
     # Check the estimand against the dataset
     check_inputs(Ψ, dataset, ose.prevalence)
-    # Detect missing outcomes and add censoring indicator if needed
-    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    # Add censoring indicator if needed
     if ipcw
         add_censoring_indicator!(dataset, Ψ.outcome)
     end
@@ -263,29 +276,30 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, dataset)
     # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
     initial_factors = get_relevant_factors(Ψ; dataset=ipcw ? dataset : nothing)
-    fluctuation_dataset = get_fluctuation_dataset(dataset, initial_factors;
+    evaluation_dataset = get_evaluation_dataset(dataset, initial_factors;
         prevalence=ose.prevalence,
         verbosity=verbosity
     )
-    initial_factors_dataset = choose_initial_dataset(dataset, fluctuation_dataset;
-        train_validation_indices=train_validation_indices, 
-        prevalence=ose.prevalence
-    )
-    prevalence_weights = compute_prevalence_weights(ose.prevalence, initial_factors_dataset[!, initial_factors.outcome_mean.outcome])
+
+    # Nuisance fitting: original dataset in vanilla mode (each estimator filters internally),
+    # evaluation dataset in CV/prevalence mode (for fold index consistency / matched controls)
+    fitting_dataset = (train_validation_indices !== nothing || ose.prevalence !== nothing) ? evaluation_dataset : dataset
+
+    prevalence_weights = compute_prevalence_weights(ose.prevalence, fitting_dataset[!, initial_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(;models=ose.models, train_validation_indices=train_validation_indices, prevalence_weights=prevalence_weights)
     initial_factors_estimate = initial_factors_estimator(
-        initial_factors, 
-        initial_factors_dataset;
-        cache=cache, 
+        initial_factors,
+        fitting_dataset;
+        cache=cache,
         verbosity=verbosity,
         acceleration=acceleration
     )
     # Get propensity score truncation threshold
-    n = nrows(fluctuation_dataset)
+    n = nrows(evaluation_dataset)
     ps_lowerbound = ps_lower_bound(n, ose.ps_lowerbound)
 
     # Gradient and estimate
-    IC, Ψ̂ = gradient_and_estimate(ose, Ψ, initial_factors_estimate, fluctuation_dataset, prevalence_weights; ps_lowerbound=ps_lowerbound)
+    IC, Ψ̂ = gradient_and_estimate(ose, Ψ, initial_factors_estimate, evaluation_dataset, prevalence_weights; ps_lowerbound=ps_lowerbound)
     σ̂ = std(IC)
     n = size(IC, 1)
     verbosity >= 1 && @info "Done."

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -12,30 +12,33 @@ mutable struct Tmle <: Estimator
     max_iter::Int
     machine_cache::Bool
     prevalence::Union{Nothing, Float64}
+    ipcw::Bool
     function Tmle(
-        models, 
-        resampling, 
-        collaborative_strategy, 
-        ps_lowerbound, 
-        weighted, 
-        tol, 
-        max_iter, 
+        models,
+        resampling,
+        collaborative_strategy,
+        ps_lowerbound,
+        weighted,
+        tol,
+        max_iter,
         machine_cache,
-        prevalence
+        prevalence,
+        ipcw
     )
         if resampling === nothing && collaborative_strategy !== nothing
             @warn("Collaborative TMLE requires a resampling strategy but none was provided. Using the default resampling strategy.")
             resampling = default_resampling(collaborative_strategy)
         end
         return new(
-            models, 
-            resampling, 
-            collaborative_strategy, 
-            ps_lowerbound, 
-            weighted, tol, 
-            max_iter, 
+            models,
+            resampling,
+            collaborative_strategy,
+            ps_lowerbound,
+            weighted, tol,
+            max_iter,
             machine_cache,
-            prevalence
+            prevalence,
+            ipcw
         )
     end
 end
@@ -60,11 +63,11 @@ been show to be more robust to positivity violation in practice.
 - max_iter (default: 1): Maximum number of iterations for the TMLE algorithm.
 - machine_cache (default: false): Whether MLJ.machine created during estimation should cache data.
 - prevalence (default: nothing): If provided, the prevalence weights will be used to weight the observations to match the true prevalence of the source population.
+- ipcw (default: true): Whether or not to apply Inverse Probability of Censoring weighting if the outcome column contains `missing` values.
 
 # Missing outcomes (IPCW)
 
-When the outcome column contains `missing` values, Inverse Probability of Censoring Weighting
-(IPCW) is automatically applied. A binary censoring model `π(W) = P(Δ=1 | W)` is fit to predict
+If `tmle.ipcw == true` and the outcome column contains `missing` values, a binary censoring model `π(W) = P(Δ=1 | W)` is fit to predict
 whether the outcome is observed, and the efficient influence curve is reweighted by `Δ/π` to
 correct for outcome missingness. This is valid under a Missing at Random (MAR) assumption — i.e.
 the probability of observing the outcome may depend on treatments and covariates, but not on the
@@ -104,7 +107,8 @@ function Tmle(;
     tol=nothing, 
     max_iter=1, 
     machine_cache=false,
-    prevalence=nothing
+    prevalence=nothing,
+    ipcw=true
     )
     Tmle(
         models, 
@@ -114,13 +118,14 @@ function Tmle(;
         weighted, tol, 
         max_iter, 
         machine_cache,
-        prevalence
+        prevalence,
+        ipcw
     )
 end
 
 function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
     # Detect missing outcomes
-    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    ipcw = tmle.ipcw & has_missing_outcomes(dataset, Ψ.outcome)
     if ipcw && tmle.prevalence !== nothing
         throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
     end
@@ -128,19 +133,17 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     check_inputs(Ψ, dataset, tmle.prevalence)
     # Add censoring indicator if needed
     if ipcw
-        add_censoring_indicator!(dataset, Ψ.outcome)
+        dataset = add_censoring_indicator(dataset, Ψ.outcome)
     end
     # Initial fit of the SCM's relevant factors
-    relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy, dataset=ipcw ? dataset : nothing)
-    fluctuation_dataset = get_fluctuation_dataset(dataset, relevant_factors;
-        prevalence=tmle.prevalence, 
+    relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy, ipcw=ipcw)
+    initial_factors_dataset = get_initial_dataset(dataset, relevant_factors;
+        prevalence=tmle.prevalence,
         verbosity=verbosity
     )
-    # Make train-validation pairs from the evaluation dataset so fold indices align
-    train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, fluctuation_dataset)
-
-    initial_factors_dataset = choose_initial_dataset(dataset, fluctuation_dataset;
-        train_validation_indices=train_validation_indices, prevalence=tmle.prevalence, ipcw=ipcw)
+    # Fold indices are built on the initial (nuisance) dataset
+    train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, initial_factors_dataset)
+    fluctuation_dataset = get_fluctuation_dataset(initial_factors_dataset, relevant_factors)
 
     prevalence_weights = compute_prevalence_weights(tmle.prevalence, initial_factors_dataset[!, relevant_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy; 
@@ -156,12 +159,16 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
         machine_cache=tmle.machine_cache,
         acceleration=acceleration
     )
+    # Nuisances were fit on the full dataset (each model dropping only the rows it can't use), but
+    # the fluctuation/gradient runs on the covariate-complete subset. Realign CV fold indices to
+    # that subset so out-of-fold predictions land on the right rows. No-op without CV.
+    if train_validation_indices !== nothing
+        keep = findall(fluctuation_row_mask(initial_factors_dataset, relevant_factors))
+        initial_factors_estimate = align_to_rows(initial_factors_estimate, keep)
+    end
     # Get propensity score truncation threshold
     n = nrows(fluctuation_dataset)
     ps_lowerbound = ps_lower_bound(n, tmle.ps_lowerbound)
-
-    # Compute IPCW weights if needed
-    ipcw_weights = compute_ipcw_weights(initial_factors_estimate, fluctuation_dataset; ps_lowerbound=ps_lowerbound)
 
     # Fluctuation initial factors
     targeted_factors_estimator = get_targeted_estimator(
@@ -175,8 +182,7 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
         weighted=tmle.weighted,
         machine_cache=tmle.machine_cache,
         models=tmle.models,
-        prevalence_weights=prevalence_weights,
-        ipcw_weights=ipcw_weights
+        prevalence_weights=prevalence_weights
     )
     targeted_factors_estimate = targeted_factors_estimator(relevant_factors, fluctuation_dataset; 
         cache=cache, 
@@ -209,6 +215,7 @@ mutable struct Ose <: Estimator
     ps_lowerbound::Union{Float64, Nothing}
     machine_cache::Bool
     prevalence::Union{Nothing, Float64}
+    ipcw::Bool
 end
 
 """
@@ -227,12 +234,8 @@ result in a data adaptive definition as described in [here](https://pubmed.ncbi.
 - machine_cache: Whether MLJ.machine created during estimation should cache data.
 - prevalence: The prevalence of the outcome in the population. If provided, the estimator will use case control 
 weights to correct for biased sampling.
-
-# Missing outcomes (IPCW)
-
-When the outcome column contains `missing` values, Inverse Probability of Censoring Weighting
-(IPCW) is automatically applied. See the `Tmle` docstring for details on the IPCW mechanism,
-modeling assumptions, and how to customize the censoring model.
+- ipcw (default: true): Whether or not to apply Inverse Probability of Censoring weighting if the outcome column contains `missing` values.
+See the `Tmle` docstring for details on the IPCW mechanism, modeling assumptions, and how to customize the censoring model.
 
 # Run Argument
 
@@ -251,12 +254,12 @@ ose = Ose()
 Ψ̂ₙ, cache = ose(Ψ, dataset)
 ```
 """
-Ose(;models=default_models(), resampling=nothing, ps_lowerbound=1e-8, machine_cache=false, prevalence=nothing) = 
-    Ose(models, resampling, ps_lowerbound, machine_cache, prevalence)
+Ose(;models=default_models(), resampling=nothing, ps_lowerbound=1e-8, machine_cache=false, prevalence=nothing, ipcw=true) =
+    Ose(models, resampling, ps_lowerbound, machine_cache, prevalence, ipcw)
 
 function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
     # Detect missing outcomes
-    ipcw = has_missing_outcomes(dataset, Ψ.outcome)
+    ipcw = ose.ipcw & has_missing_outcomes(dataset, Ψ.outcome)
     if ipcw && ose.prevalence !== nothing
         throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
     end
@@ -264,19 +267,17 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     check_inputs(Ψ, dataset, ose.prevalence)
     # Add censoring indicator if needed
     if ipcw
-        add_censoring_indicator!(dataset, Ψ.outcome)
+        dataset = add_censoring_indicator(dataset, Ψ.outcome)
     end
     # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
-    initial_factors = get_relevant_factors(Ψ; dataset=ipcw ? dataset : nothing)
-    fluctuation_dataset = get_fluctuation_dataset(dataset, initial_factors;
+    initial_factors = get_relevant_factors(Ψ; ipcw=ipcw)
+    initial_factors_dataset = get_initial_dataset(dataset, initial_factors;
         prevalence=ose.prevalence,
         verbosity=verbosity
     )
-    # Make train-validation pairs from the evaluation dataset so fold indices align
-    train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, fluctuation_dataset)
-
-    initial_factors_dataset = choose_initial_dataset(dataset, fluctuation_dataset;
-        train_validation_indices=train_validation_indices, prevalence=ose.prevalence, ipcw=ipcw)
+    # Fold indices are built on the initial (nuisance) dataset.
+    train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, initial_factors_dataset)
+    fluctuation_dataset = get_fluctuation_dataset(initial_factors_dataset, initial_factors)
 
     prevalence_weights = compute_prevalence_weights(ose.prevalence, initial_factors_dataset[!, initial_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(;models=ose.models, train_validation_indices=train_validation_indices, prevalence_weights=prevalence_weights)
@@ -287,6 +288,12 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
         verbosity=verbosity,
         acceleration=acceleration
     )
+    # Realign CV fold indices from the full dataset to the covariate-complete fluctuation subset
+    # (see the TMLE call method). No-op without CV.
+    if train_validation_indices !== nothing
+        keep = findall(fluctuation_row_mask(initial_factors_dataset, initial_factors))
+        initial_factors_estimate = align_to_rows(initial_factors_estimate, keep)
+    end
     # Get propensity score truncation threshold
     n = nrows(fluctuation_dataset)
     ps_lowerbound = ps_lower_bound(n, ose.ps_lowerbound)
@@ -310,7 +317,7 @@ function gradient_and_estimate(::Ose, Ψ, factors, dataset, prevalence_weights; 
     Q = factors.outcome_mean
     G = factors.propensity_score
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
-    gradient_Y_X = ∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound, censoring_score=factors.censoring_score)
+    gradient_Y_X = ∇YX(Ψ, Q, G, dataset; censoring_score=factors.censoring_score, ps_lowerbound=ps_lowerbound)
     y = float(dataset[!, Q.estimand.outcome])
     IC, Ψ̂ = gradient_and_estimate(ctf_agg, gradient_Y_X, y, prevalence_weights)
     IC_mean = mean(IC)

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -74,9 +74,10 @@ The censoring model's covariates default to the same parents as the outcome mean
 custom censoring model, pass it via the `models` dict under the key `:C_default` or under the
 censoring indicator name (e.g. `Symbol("Δ_Y")`). See also `default_models`.
 
-The outcome mean (Q) is always fit on complete cases only, while the propensity score (G) and
-censoring model (π) are fit on all observations. The influence curve and plugin estimate are
-evaluated on all observations with non-missing covariates.
+The outcome mean (Q) is fit on complete cases only (observed outcomes), while the propensity
+score (G) and censoring model (π) are fit on all covariate-complete observations (including
+those with missing outcomes). The influence curve and plugin estimate are evaluated on all
+covariate-complete observations.
 
 # Run Argument
 
@@ -129,7 +130,7 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     if ipcw
         add_censoring_indicator!(dataset, Ψ.outcome)
     end
-    # Initial fit of the SCM's relevant factors (pass dataset for IPCW detection)
+    # Initial fit of the SCM's relevant factors
     relevant_factors = get_relevant_factors(Ψ, collaborative_strategy=tmle.collaborative_strategy, dataset=ipcw ? dataset : nothing)
     fluctuation_dataset = get_fluctuation_dataset(dataset, relevant_factors;
         prevalence=tmle.prevalence, 
@@ -138,21 +139,18 @@ function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(),
     # Make train-validation pairs from the evaluation dataset so fold indices align
     train_validation_indices = get_train_validation_indices(tmle.resampling, Ψ, fluctuation_dataset)
 
-    fitting_dataset = if train_validation_indices !== nothing || tmle.prevalence !== nothing || ipcw
-        fluctuation_dataset
-    else
-        dataset
-    end
+    initial_factors_dataset = choose_initial_dataset(dataset, fluctuation_dataset;
+        train_validation_indices=train_validation_indices, prevalence=tmle.prevalence, ipcw=ipcw)
 
-    prevalence_weights = compute_prevalence_weights(tmle.prevalence, fitting_dataset[!, relevant_factors.outcome_mean.outcome])
+    prevalence_weights = compute_prevalence_weights(tmle.prevalence, initial_factors_dataset[!, relevant_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(tmle.collaborative_strategy; 
         train_validation_indices=train_validation_indices, 
         models=tmle.models,
         prevalence_weights=prevalence_weights
     )
     verbosity >= 1 && @info "Estimating nuisance parameters."
-
-    initial_factors_estimate = initial_factors_estimator(relevant_factors, fitting_dataset;
+    
+    initial_factors_estimate = initial_factors_estimator(relevant_factors, initial_factors_dataset; 
         cache=cache, 
         verbosity=verbosity-1,
         machine_cache=tmle.machine_cache,
@@ -277,18 +275,15 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
     # Make train-validation pairs from the evaluation dataset so fold indices align
     train_validation_indices = get_train_validation_indices(ose.resampling, Ψ, fluctuation_dataset)
 
-    fitting_dataset = if train_validation_indices !== nothing || ose.prevalence !== nothing || ipcw
-        fluctuation_dataset
-    else
-        dataset
-    end
+    initial_factors_dataset = choose_initial_dataset(dataset, fluctuation_dataset;
+        train_validation_indices=train_validation_indices, prevalence=ose.prevalence, ipcw=ipcw)
 
-    prevalence_weights = compute_prevalence_weights(ose.prevalence, fitting_dataset[!, initial_factors.outcome_mean.outcome])
+    prevalence_weights = compute_prevalence_weights(ose.prevalence, initial_factors_dataset[!, initial_factors.outcome_mean.outcome])
     initial_factors_estimator = CMRelevantFactorsEstimator(;models=ose.models, train_validation_indices=train_validation_indices, prevalence_weights=prevalence_weights)
     initial_factors_estimate = initial_factors_estimator(
-        initial_factors,
-        fitting_dataset;
-        cache=cache,
+        initial_factors, 
+        initial_factors_dataset;
+        cache=cache, 
         verbosity=verbosity,
         acceleration=acceleration
     )

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -7,10 +7,11 @@ mutable struct Fluctuation <: MLJBase.Supervised
     weighted::Bool
     cache::Bool
     prevalence_weights::Union{Nothing, Vector{Float64}}
+    ipcw_weights::Union{Nothing, Vector{Float64}}
 end
 
-Fluctuation(Ψ, initial_factors; tol=nothing, max_iter=1, ps_lowerbound=1e-8, weighted=false, cache=false, prevalence_weights=nothing) =
-    Fluctuation(Ψ, initial_factors, tol, max_iter, ps_lowerbound, weighted, cache, prevalence_weights)
+Fluctuation(Ψ, initial_factors; tol=nothing, max_iter=1, ps_lowerbound=1e-8, weighted=false, cache=false, prevalence_weights=nothing, ipcw_weights=nothing) =
+    Fluctuation(Ψ, initial_factors, tol, max_iter, ps_lowerbound, weighted, cache, prevalence_weights, ipcw_weights)
 
 one_dimensional_path(target_scitype::Type{T}) where T <: AbstractVector{<:MLJBase.Continuous} = LinearRegressor(fit_intercept=false, offsetcol = :offset)
 one_dimensional_path(target_scitype::Type{T}) where T <: AbstractVector{<:Finite} = LinearBinaryClassifier(fit_intercept=false, offsetcol = :offset)
@@ -58,6 +59,10 @@ function initialize_observed_cache(model, X, y)
         ps_lowerbound=model.ps_lowerbound,
         weighted_fluctuation=model.weighted
     )
+    # IPCW: incorporate precomputed Δ/π weights
+    if model.ipcw_weights !== nothing
+        w .*= model.ipcw_weights
+    end
     ŷ = MLJBase.predict(Q⁰, X)
     return Dict{Symbol, Any}(:H => H, :w => w, :ŷ => ŷ, :y => float(y))
 end

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -7,11 +7,19 @@ mutable struct Fluctuation <: MLJBase.Supervised
     weighted::Bool
     cache::Bool
     prevalence_weights::Union{Nothing, Vector{Float64}}
-    ipcw_weights::Union{Nothing, Vector{Float64}}
 end
 
-Fluctuation(Ψ, initial_factors; tol=nothing, max_iter=1, ps_lowerbound=1e-8, weighted=false, cache=false, prevalence_weights=nothing, ipcw_weights=nothing) =
-    Fluctuation(Ψ, initial_factors, tol, max_iter, ps_lowerbound, weighted, cache, prevalence_weights, ipcw_weights)
+Fluctuation(Ψ, initial_factors; tol=nothing, max_iter=1, ps_lowerbound=1e-8, weighted=false, cache=false, prevalence_weights=nothing) =
+    Fluctuation(Ψ, initial_factors, tol, max_iter, ps_lowerbound, weighted, cache, prevalence_weights)
+
+"""
+The fluctuation reads the censoring indicator `Δ_Y` off the clever covariate (IPCW), so it must
+be kept in `X` even though it is not one of the outcome model's parents.
+"""
+function extra_fit_columns(model::Fluctuation, estimand)
+    cs = model.initial_factors.censoring_score
+    cs === nothing ? Symbol[] : [cs.estimand.outcome]
+end
 
 one_dimensional_path(target_scitype::Type{T}) where T <: AbstractVector{<:MLJBase.Continuous} = LinearRegressor(fit_intercept=false, offsetcol = :offset)
 one_dimensional_path(target_scitype::Type{T}) where T <: AbstractVector{<:Finite} = LinearBinaryClassifier(fit_intercept=false, offsetcol = :offset)
@@ -57,11 +65,9 @@ function initialize_observed_cache(model, X, y)
     H, w = clever_covariate_and_weights(
         model.Ψ, G⁰, X;
         ps_lowerbound=model.ps_lowerbound,
-        weighted_fluctuation=model.weighted
+        weighted_fluctuation=model.weighted,
+        censoring_score=model.initial_factors.censoring_score
     )
-    if model.ipcw_weights !== nothing
-        w .*= model.ipcw_weights
-    end
     ŷ = MLJBase.predict(Q⁰, X)
     return Dict{Symbol, Any}(:H => H, :w => w, :ŷ => ŷ, :y => float(y))
 end

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -59,7 +59,6 @@ function initialize_observed_cache(model, X, y)
         ps_lowerbound=model.ps_lowerbound,
         weighted_fluctuation=model.weighted
     )
-    # IPCW: incorporate precomputed Δ/π weights
     if model.ipcw_weights !== nothing
         w .*= model.ipcw_weights
     end

--- a/src/counterfactual_mean_based/gradient.jl
+++ b/src/counterfactual_mean_based/gradient.jl
@@ -52,12 +52,20 @@ Computes the projection of the gradient on the (Y | X) space.
 
 This part of the gradient is evaluated on the original dataset. All quantities have been precomputed and cached.
 """
-function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; ps_lowerbound=1e-8)
+function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; ps_lowerbound=1e-8, censoring_score=nothing)
     # Maybe can cache some results (H and E[Y|X]) to improve perf here
     H, w = clever_covariate_and_weights(Ψ, G, dataset; ps_lowerbound=ps_lowerbound)
     y = float(dataset[!, Q.estimand.outcome])
     Ey = expected_value(Q, dataset)
-    return ∇YX(H, y, Ey, w)
+    grad = ∇YX(H, y, Ey, w)
+    # IPCW: multiply by Δ/π to reweight for missing outcomes
+    if censoring_score !== nothing
+        Δ = get_censoring_indicator(dataset, Q.estimand.outcome)
+        π = likelihood(censoring_score, dataset)
+        truncate!(π, ps_lowerbound)
+        grad .*= Δ ./ π
+    end
+    return grad
 end
 
 
@@ -66,7 +74,7 @@ function gradient_and_plugin_estimate(Ψ::StatisticalCMCompositeEstimand, factor
     G = factors.propensity_score
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
     Ψ̂ = plugin_estimate(ctf_agg)
-    IC = ∇YX(Ψ, Q, G, dataset; ps_lowerbound = ps_lowerbound) .+ ∇W(ctf_agg, Ψ̂)
+    IC = ∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound, censoring_score=factors.censoring_score) .+ ∇W(ctf_agg, Ψ̂)
     return IC, Ψ̂
 end
 

--- a/src/counterfactual_mean_based/gradient.jl
+++ b/src/counterfactual_mean_based/gradient.jl
@@ -58,12 +58,8 @@ function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; ps_lowerbound=
     y = float(dataset[!, Q.estimand.outcome])
     Ey = expected_value(Q, dataset)
     grad = ∇YX(H, y, Ey, w)
-    # IPCW: multiply by Δ/π to reweight for missing outcomes
     if censoring_score !== nothing
-        Δ = get_censoring_indicator(dataset, Q.estimand.outcome)
-        π = likelihood(censoring_score, dataset)
-        truncate!(π, ps_lowerbound)
-        grad .*= Δ ./ π
+        grad .*= compute_ipcw_weights(censoring_score, dataset, Q.estimand.outcome; ps_lowerbound=ps_lowerbound)
     end
     return grad
 end

--- a/src/counterfactual_mean_based/gradient.jl
+++ b/src/counterfactual_mean_based/gradient.jl
@@ -52,16 +52,12 @@ Computes the projection of the gradient on the (Y | X) space.
 
 This part of the gradient is evaluated on the original dataset. All quantities have been precomputed and cached.
 """
-function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; ps_lowerbound=1e-8, censoring_score=nothing)
+function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; censoring_score=nothing, ps_lowerbound=1e-8)
     # Maybe can cache some results (H and E[Y|X]) to improve perf here
-    H, w = clever_covariate_and_weights(Ψ, G, dataset; ps_lowerbound=ps_lowerbound)
+    H, w = clever_covariate_and_weights(Ψ, G, dataset; censoring_score=censoring_score, ps_lowerbound=ps_lowerbound)
     y = float(dataset[!, Q.estimand.outcome])
     Ey = expected_value(Q, dataset)
-    grad = ∇YX(H, y, Ey, w)
-    if censoring_score !== nothing
-        grad .*= compute_ipcw_weights(censoring_score, dataset, Q.estimand.outcome; ps_lowerbound=ps_lowerbound)
-    end
-    return grad
+    return ∇YX(H, y, Ey, w)
 end
 
 
@@ -70,7 +66,7 @@ function gradient_and_plugin_estimate(Ψ::StatisticalCMCompositeEstimand, factor
     G = factors.propensity_score
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
     Ψ̂ = plugin_estimate(ctf_agg)
-    IC = ∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound, censoring_score=factors.censoring_score) .+ ∇W(ctf_agg, Ψ̂)
+    IC = ∇YX(Ψ, Q, G, dataset; censoring_score=factors.censoring_score, ps_lowerbound = ps_lowerbound) .+ ∇W(ctf_agg, Ψ̂)
     return IC, Ψ̂
 end
 

--- a/src/counterfactual_mean_based/nuisance_estimators.jl
+++ b/src/counterfactual_mean_based/nuisance_estimators.jl
@@ -95,16 +95,23 @@ If there is a collaborative strategy, `train_validation_indices` are ignored to 
 """
 CMRelevantFactorsEstimator(collaborative_strategy; models, train_validation_indices=nothing, prevalence_weights=nothing) = CMRelevantFactorsEstimator(nothing, models, prevalence_weights)
 
-function acquire_model(models, key, dataset, is_propensity_score)
-    # If the model is in models return it
+"""
+    acquire_model(models, key, dataset, default_model_key=nothing)
+
+Look up a model from `models` for the variable `key`. If `key` is found directly, return it.
+Otherwise fall back to `default_model_key`. When `default_model_key` is `nothing`, the default
+is inferred from the data: `:Q_binary_default` or `:Q_continuous_default` depending on whether
+`key` is binary in `dataset`.
+
+If the default key is also missing from `models`, a `KeyError` is raised.
+"""
+function acquire_model(models, key, dataset, default_model_key::Union{Nothing, Symbol}=nothing)
     haskey(models, key) && return models[key]
-    # Otherwise, if the required model is for a propensity_score, return the default
-    model_default = :G_default
-    if !is_propensity_score
-        # Finally, if the required model is an outcome_mean, find the type from the data
-        model_default = is_binary(dataset, key) ? :Q_binary_default : :Q_continuous_default
+    if default_model_key === nothing
+        default_model_key = is_binary(dataset, key) ? :Q_binary_default : :Q_continuous_default
     end
-    return models[model_default]
+    haskey(models, default_model_key) && return models[default_model_key]
+    throw(KeyError(default_model_key))
 end
 
 function build_propensity_score_estimator(propensity_score, models, dataset;
@@ -114,7 +121,7 @@ function build_propensity_score_estimator(propensity_score, models, dataset;
     cd_estimators = Dict()
     for conditional_distribution in propensity_score
         outcome = conditional_distribution.outcome
-        model = acquire_model(models, outcome, dataset, true)
+        model = acquire_model(models, outcome, dataset, :G_default)
         cd_estimators[outcome] = ConditionalDistributionEstimator(model, train_validation_indices, prevalence_weights=prevalence_weights)
     end
     return JointConditionalDistributionEstimator(cd_estimators)
@@ -153,7 +160,7 @@ function estimate_outcome_mean(outcome_mean, models, dataset;
     acceleration=CPU1(),
     prevalence_weights=nothing
     )
-    outcome_model = acquire_model(models, outcome_mean.outcome, dataset, false)
+    outcome_model = acquire_model(models, outcome_mean.outcome, dataset)
     outcome_mean_estimator = ConditionalDistributionEstimator(
         outcome_model,
         train_validation_indices,
@@ -229,9 +236,26 @@ function estimate_propensity_score_and_outcome_mean(
     return fetch.([propensity_score_estimate, outcome_mean_estimate])
 end
 
-function (estimator::CMRelevantFactorsEstimator)(estimand, dataset; 
-    cache=Dict(), 
-    verbosity=1, 
+function estimate_censoring_score(censoring_score, models, dataset;
+    train_validation_indices=nothing,
+    cache=Dict(),
+    verbosity=1,
+    machine_cache=false,
+    prevalence_weights=nothing
+    )
+    model = acquire_model(models, censoring_score.outcome, dataset, :C_default)
+    censoring_estimator = ConditionalDistributionEstimator(model, train_validation_indices, prevalence_weights=prevalence_weights)
+    return try_fit_ml_estimator(censoring_estimator, censoring_score, dataset;
+        error_fn=default_fit_error_msg,
+        cache=cache,
+        verbosity=verbosity,
+        machine_cache=machine_cache
+    )
+end
+
+function (estimator::CMRelevantFactorsEstimator)(estimand, dataset;
+    cache=Dict(),
+    verbosity=1,
     machine_cache=false,
     acceleration=CPU1()
     )
@@ -260,9 +284,22 @@ function (estimator::CMRelevantFactorsEstimator)(estimand, dataset;
         machine_cache=machine_cache,
         prevalence_weights=prevalence_weights
     )
-    
+
+    # Estimate censoring score if needed
+    censoring_score_estimate = nothing
+    if estimand.censoring_score !== nothing
+        censoring_score_estimate = estimate_censoring_score(
+            estimand.censoring_score, models, dataset;
+            train_validation_indices=train_validation_indices,
+            cache=cache,
+            verbosity=verbosity,
+            machine_cache=machine_cache,
+            prevalence_weights=prevalence_weights
+        )
+    end
+
     # Build estimate
-    estimate = MLCMRelevantFactors(estimand, outcome_mean_estimate, propensity_score_estimate)
+    estimate = MLCMRelevantFactors(estimand, outcome_mean_estimate, propensity_score_estimate, censoring_score_estimate)
     # Update cache
     update_cache!(cache, estimand, estimator, estimate)
 
@@ -299,11 +336,12 @@ function (estimator::CMBasedTMLE)(estimand, dataset;
         verbosity=verbosity,
         machine_cache=machine_cache
     )
-    # Do not fluctuate propensity score
+    # Do not fluctuate propensity score or censoring score
     fluctuated_propensity_score = fluctuation_model.initial_factors.propensity_score
-    
+    censoring_score = fluctuation_model.initial_factors.censoring_score
+
     # Build estimate
-    estimate = MLCMRelevantFactors(estimand, fluctuated_outcome_mean, fluctuated_propensity_score)
+    estimate = MLCMRelevantFactors(estimand, fluctuated_outcome_mean, fluctuated_propensity_score, censoring_score)
 
     return estimate
 end
@@ -465,7 +503,8 @@ function get_targeted_estimator(
     weighted=true,
     machine_cache=false,
     models=nothing,
-    prevalence_weights=nothing
+    prevalence_weights=nothing,
+    ipcw_weights=nothing
     )
     fluctuation_model = Fluctuation(Ψ, initial_factors_estimate; 
         tol=tol,
@@ -473,7 +512,8 @@ function get_targeted_estimator(
         ps_lowerbound=ps_lowerbound, 
         weighted=weighted,
         cache=machine_cache,
-        prevalence_weights=prevalence_weights
+        prevalence_weights=prevalence_weights,
+        ipcw_weights=ipcw_weights
     )
     if collaborative_strategy isa CollaborativeStrategy
         return CMBasedCTMLE(fluctuation_model, collaborative_strategy, train_validation_indices, models)

--- a/src/counterfactual_mean_based/nuisance_estimators.jl
+++ b/src/counterfactual_mean_based/nuisance_estimators.jl
@@ -285,7 +285,8 @@ function (estimator::CMRelevantFactorsEstimator)(estimand, dataset;
         prevalence_weights=prevalence_weights
     )
 
-    # Estimate censoring score if needed
+    # Estimate censoring score if needed (no prevalence_weights: censoring
+    # model should not be reweighted by case-control prevalence)
     censoring_score_estimate = nothing
     if estimand.censoring_score !== nothing
         censoring_score_estimate = estimate_censoring_score(
@@ -293,8 +294,7 @@ function (estimator::CMRelevantFactorsEstimator)(estimand, dataset;
             train_validation_indices=train_validation_indices,
             cache=cache,
             verbosity=verbosity,
-            machine_cache=machine_cache,
-            prevalence_weights=prevalence_weights
+            machine_cache=machine_cache
         )
     end
 

--- a/src/counterfactual_mean_based/nuisance_estimators.jl
+++ b/src/counterfactual_mean_based/nuisance_estimators.jl
@@ -503,8 +503,7 @@ function get_targeted_estimator(
     weighted=true,
     machine_cache=false,
     models=nothing,
-    prevalence_weights=nothing,
-    ipcw_weights=nothing
+    prevalence_weights=nothing
     )
     fluctuation_model = Fluctuation(Ψ, initial_factors_estimate; 
         tol=tol,
@@ -512,8 +511,7 @@ function get_targeted_estimator(
         ps_lowerbound=ps_lowerbound, 
         weighted=weighted,
         cache=machine_cache,
-        prevalence_weights=prevalence_weights,
-        ipcw_weights=ipcw_weights
+        prevalence_weights=prevalence_weights
     )
     if collaborative_strategy isa CollaborativeStrategy
         return CMBasedCTMLE(fluctuation_model, collaborative_strategy, train_validation_indices, models)

--- a/src/counterfactual_mean_based/nuisance_estimators.jl
+++ b/src/counterfactual_mean_based/nuisance_estimators.jl
@@ -236,6 +236,8 @@ function estimate_propensity_score_and_outcome_mean(
     return fetch.([propensity_score_estimate, outcome_mean_estimate])
 end
 
+estimate_censoring_score(censoring_score::Nothing, models, dataset; kwargs...) = nothing
+
 function estimate_censoring_score(censoring_score, models, dataset;
     train_validation_indices=nothing,
     cache=Dict(),
@@ -287,16 +289,13 @@ function (estimator::CMRelevantFactorsEstimator)(estimand, dataset;
 
     # Estimate censoring score if needed (no prevalence_weights: censoring
     # model should not be reweighted by case-control prevalence)
-    censoring_score_estimate = nothing
-    if estimand.censoring_score !== nothing
-        censoring_score_estimate = estimate_censoring_score(
-            estimand.censoring_score, models, dataset;
-            train_validation_indices=train_validation_indices,
-            cache=cache,
-            verbosity=verbosity,
-            machine_cache=machine_cache
-        )
-    end
+    censoring_score_estimate = estimate_censoring_score(
+        estimand.censoring_score, models, dataset;
+        train_validation_indices=train_validation_indices,
+        cache=cache,
+        verbosity=verbosity,
+        machine_cache=machine_cache
+    )
 
     # Build estimate
     estimate = MLCMRelevantFactors(estimand, outcome_mean_estimate, propensity_score_estimate, censoring_score_estimate)

--- a/src/estimates.jl
+++ b/src/estimates.jl
@@ -119,6 +119,38 @@ function MLJBase.predict(estimate::SampleSplitMLConditionalDistribution, dataset
     return cv_predict(estimate, X)
 end
 
+"""
+    align_train_validation_indices(train_validation_indices, keep::Vector{Int})
+
+Remap fold indices expressed in the full-dataset row space into the row space of the
+covariate-complete subset (`keep` lists the full-space positions of the subset rows, in order).
+Rows dropped from the subset are removed from their folds. Used to realign fitted CV nuisances so
+their out-of-fold predictions land on the correct rows of the fluctuation dataset (IPCW with
+missing covariates). When `keep == 1:n` this is the identity.
+"""
+function align_train_validation_indices(train_validation_indices, keep::AbstractVector{Int})
+    full_to_sub = Dict(full => sub for (sub, full) in enumerate(keep))
+    remap(idx) = [full_to_sub[i] for i in idx if haskey(full_to_sub, i)]
+    return [(remap(train_idx), remap(val_idx)) for (train_idx, val_idx) in train_validation_indices]
+end
+
+"""
+    align_to_rows(estimate, keep::Vector{Int})
+
+Return an estimate whose stored CV fold indices address the covariate-complete subset identified
+by `keep` instead of the full initial dataset. The per-fold machines are untouched (they were
+trained on the full dataset); only the indices used for out-of-fold prediction are remapped.
+Non sample-split estimates predict on any dataset directly and are returned unchanged.
+"""
+align_to_rows(estimate::MLConditionalDistribution, keep) = estimate
+
+align_to_rows(estimate::SampleSplitMLConditionalDistribution, keep) =
+    SampleSplitMLConditionalDistribution(
+        estimate.estimand,
+        align_train_validation_indices(estimate.train_validation_indices, keep),
+        estimate.machines
+    )
+
 #####################################################################
 ###               ConditionalDistributionEstimate                 ###
 #####################################################################
@@ -158,6 +190,9 @@ struct JointConditionalDistributionEstimate{T, N} <: Estimate
     estimand::Tuple{Vararg{ConditionalDistribution, N}}
     components::Tuple{Vararg{T, N}}
 end
+
+align_to_rows(estimate::JointConditionalDistributionEstimate, keep) =
+    JointConditionalDistributionEstimate(estimate.estimand, map(c -> align_to_rows(c, keep), estimate.components))
 
 #####################################################################
 ###                        Joint Estimate                         ###

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -69,29 +69,16 @@ Calculates weights for a case-control study to use in the fitting of nuisance fu
   (e.g. censoring indicator Δ). When provided, case/control counts use only observed rows,
   and unobserved rows get weight 1.0 (neutral; zeroed by IPCW's Δ/π).
 """
-function compute_prevalence_weights(prevalence::Float64, y::AbstractVector; observed=nothing)
-    if observed !== nothing
-        n_cases = count(i -> observed[i] == 1 && y[i] == 1, eachindex(y))
-        n_controls = count(i -> observed[i] == 1 && y[i] == 0, eachindex(y))
-    else
-        n_cases = count(==(1), y)
-        n_controls = count(==(0), y)
-    end
-    J = n_controls ÷ n_cases
+function compute_prevalence_weights(prevalence::Float64, y::AbstractVector)
+    J = sum(y .== 0) ÷ sum(y .== 1)
     weights = Vector{Float64}(undef, length(y))
     for i in eachindex(y)
-        if observed !== nothing && observed[i] != 1
-            weights[i] = 1.0  # neutral weight; zeroed by IPCW's Δ/π
-        elseif y[i] == 1
-            weights[i] = prevalence
-        else
-            weights[i] = (1 - prevalence) / J
-        end
+        weights[i] = y[i] == 1 ? prevalence : (1 - prevalence) / J
     end
     return weights
 end
 
-compute_prevalence_weights(::Nothing, y; observed=nothing) = nothing
+compute_prevalence_weights(::Nothing, y) = nothing
 
 get_training_prevalence_weights(::Nothing, train_indices) = nothing
 
@@ -113,22 +100,13 @@ function (estimator::MLConditionalDistributionEstimator)(estimand, dataset;
 
     verbosity > 0 && @info(string("Estimating: ", string_repr(estimand)))
     # Otherwise estimate
-    relevant_dataset = TMLE.selectcols(dataset, variables(estimand))
-    # Track which rows are complete for weight alignment
-    complete_rows = completecases(relevant_dataset)
-    relevant_dataset = relevant_dataset[complete_rows, :]
-    disallowmissing!(relevant_dataset)
+    relevant_dataset = nomissing(dataset, variables(estimand))
     relevant_dataset = training_rows(relevant_dataset, estimator.train_validation_indices)
     # Fit Conditional DIstribution using MLJ
     X = TMLE.selectcols(relevant_dataset, estimand.parents)
     y = relevant_dataset[!, estimand.outcome]
-    # If prevalence weights are provided, filter to match complete rows then training rows
-    weights = if estimator.prevalence_weights !== nothing
-        filtered = estimator.prevalence_weights[complete_rows]
-        get_training_prevalence_weights(filtered, estimator.train_validation_indices)
-    else
-        nothing
-    end
+    # If a prevalence weights are provided, we use it to fit the model
+    weights = get_training_prevalence_weights(estimator.prevalence_weights, estimator.train_validation_indices)
     
     mach = fit_mlj_model(estimator.model, X, y; 
         parents=estimand.parents, 

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -60,22 +60,38 @@ function fit_mlj_model(model, X, y; parents=names(X), cache=false, weights=nothi
 end
 
 """
-    compute_prevalence_weights(prevalence, y)
+    compute_prevalence_weights(prevalence, y; observed=nothing)
 
 Calculates weights for a case-control study to use in the fitting of nuisance functions.
 - `prevalence`: The prevalence of the outcome in the population.
-- `y`: The outcome variable across observations, which should be binary vector.`
+- `y`: The outcome variable across observations, which should be binary vector.
+- `observed`: Optional boolean-like vector indicating which rows have observed outcomes
+  (e.g. censoring indicator Δ). When provided, case/control counts use only observed rows,
+  and unobserved rows get weight 1.0 (neutral; zeroed by IPCW's Δ/π).
 """
-function compute_prevalence_weights(prevalence::Float64, y::AbstractVector)
-    J = sum(y .== 0) ÷ sum(y .== 1)
+function compute_prevalence_weights(prevalence::Float64, y::AbstractVector; observed=nothing)
+    if observed !== nothing
+        n_cases = count(i -> observed[i] == 1 && y[i] == 1, eachindex(y))
+        n_controls = count(i -> observed[i] == 1 && y[i] == 0, eachindex(y))
+    else
+        n_cases = count(==(1), y)
+        n_controls = count(==(0), y)
+    end
+    J = n_controls ÷ n_cases
     weights = Vector{Float64}(undef, length(y))
     for i in eachindex(y)
-        weights[i] = y[i] == 1 ? prevalence : (1 - prevalence) / J
+        if observed !== nothing && observed[i] != 1
+            weights[i] = 1.0  # neutral weight; zeroed by IPCW's Δ/π
+        elseif y[i] == 1
+            weights[i] = prevalence
+        else
+            weights[i] = (1 - prevalence) / J
+        end
     end
     return weights
 end
 
-compute_prevalence_weights(::Nothing, y) = nothing
+compute_prevalence_weights(::Nothing, y; observed=nothing) = nothing
 
 get_training_prevalence_weights(::Nothing, train_indices) = nothing
 
@@ -97,13 +113,22 @@ function (estimator::MLConditionalDistributionEstimator)(estimand, dataset;
 
     verbosity > 0 && @info(string("Estimating: ", string_repr(estimand)))
     # Otherwise estimate
-    relevant_dataset = nomissing(dataset, variables(estimand))
+    relevant_dataset = TMLE.selectcols(dataset, variables(estimand))
+    # Track which rows are complete for weight alignment
+    complete_rows = completecases(relevant_dataset)
+    relevant_dataset = relevant_dataset[complete_rows, :]
+    disallowmissing!(relevant_dataset)
     relevant_dataset = training_rows(relevant_dataset, estimator.train_validation_indices)
     # Fit Conditional DIstribution using MLJ
     X = TMLE.selectcols(relevant_dataset, estimand.parents)
     y = relevant_dataset[!, estimand.outcome]
-    # If a prevalence weights are provided, we use it to fit the model
-    weights = get_training_prevalence_weights(estimator.prevalence_weights, estimator.train_validation_indices)
+    # If prevalence weights are provided, filter to match complete rows then training rows
+    weights = if estimator.prevalence_weights !== nothing
+        filtered = estimator.prevalence_weights[complete_rows]
+        get_training_prevalence_weights(filtered, estimator.train_validation_indices)
+    else
+        nothing
+    end
     
     mach = fit_mlj_model(estimator.model, X, y; 
         parents=estimand.parents, 
@@ -149,10 +174,19 @@ function update_sample_split_machines_with_fold!(machines::Vector{Machine},
     )
     train_indices, _ = estimator.train_validation_indices[fold_id]
     train_dataset = selectrows(dataset, train_indices)
+    # Track complete rows before dropping for weight alignment
+    complete_rows = completecases(train_dataset)
+    train_dataset = train_dataset[complete_rows, :]
+    disallowmissing!(train_dataset)
     Xtrain = selectcols(train_dataset, estimand.parents)
     ytrain = train_dataset[!, estimand.outcome]
-    
-    weights = get_training_prevalence_weights(estimator.prevalence_weights, train_indices)
+
+    weights = if estimator.prevalence_weights !== nothing
+        filtered = get_training_prevalence_weights(estimator.prevalence_weights, train_indices)
+        filtered[complete_rows]
+    else
+        nothing
+    end
     machines[fold_id] = fit_mlj_model(estimator.model, Xtrain, ytrain; 
         parents=estimand.parents, 
         cache=machine_cache,

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -64,10 +64,7 @@ end
 
 Calculates weights for a case-control study to use in the fitting of nuisance functions.
 - `prevalence`: The prevalence of the outcome in the population.
-- `y`: The outcome variable across observations, which should be binary vector.
-- `observed`: Optional boolean-like vector indicating which rows have observed outcomes
-  (e.g. censoring indicator Δ). When provided, case/control counts use only observed rows,
-  and unobserved rows get weight 1.0 (neutral; zeroed by IPCW's Δ/π).
+- `y`: The outcome variable across observations, which should be binary vector.`
 """
 function compute_prevalence_weights(prevalence::Float64, y::AbstractVector)
     J = sum(y .== 0) ÷ sum(y .== 1)
@@ -88,9 +85,19 @@ get_training_prevalence_weights(weights::AbstractVector, train_indices::Tuple) =
 
 get_training_prevalence_weights(weights::AbstractVector, train_indices::AbstractVector) = weights[train_indices]
 
-function (estimator::MLConditionalDistributionEstimator)(estimand, dataset; 
-    cache=Dict(), 
-    verbosity=1, 
+"""
+    extra_fit_columns(model, estimand)
+
+Extra feature columns a model needs in `X` beyond `estimand.parents`. Empty by default; the
+`Fluctuation` overload adds the censoring indicator so IPCW can be read off the clever covariate.
+These columns are not passed as `parents`, so marginal-model detection and the model's own inputs
+are unaffected.
+"""
+extra_fit_columns(model, estimand) = Symbol[]
+
+function (estimator::MLConditionalDistributionEstimator)(estimand, dataset;
+    cache=Dict(),
+    verbosity=1,
     machine_cache=false,
     acceleration=CPU1()
     )
@@ -100,10 +107,11 @@ function (estimator::MLConditionalDistributionEstimator)(estimand, dataset;
 
     verbosity > 0 && @info(string("Estimating: ", string_repr(estimand)))
     # Otherwise estimate
-    relevant_dataset = nomissing(dataset, variables(estimand))
+    extra = extra_fit_columns(estimator.model, estimand)
+    relevant_dataset = nomissing(dataset, (variables(estimand)..., extra...))
     relevant_dataset = training_rows(relevant_dataset, estimator.train_validation_indices)
     # Fit Conditional DIstribution using MLJ
-    X = TMLE.selectcols(relevant_dataset, estimand.parents)
+    X = TMLE.selectcols(relevant_dataset, (estimand.parents..., extra...))
     y = relevant_dataset[!, estimand.outcome]
     # If a prevalence weights are provided, we use it to fit the model
     weights = get_training_prevalence_weights(estimator.prevalence_weights, estimator.train_validation_indices)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,20 +28,6 @@ fit_string(estimand) = string("Estimating: ", string_repr(estimand))
 
 unique_sorted_tuple(iter) = Tuple(sort(unique(Symbol(x) for x in iter)))
 
-"""
-For cross-validated and prevalence based estimators, the fluctuation dataset (see get_fluctuation_dataset)is used to fit the initial factors. 
-This is to avoid the expensive complications of:
-    - Equally distributing missing across folds
-    - Tracking sample_ids
-"""
-function choose_initial_dataset(dataset, fluctuation_dataset; train_validation_indices=nothing, prevalence=nothing) 
-    # In CV mode or prevalence mode, we get back to the no fluctuation_dataset
-    if !isnothing(train_validation_indices) || !isnothing(prevalence)
-        return fluctuation_dataset
-    else
-        return dataset
-    end
-end
 
 """
 If no columns are provided, we return a single intercept column to accomodate marginal distribution fitting
@@ -94,13 +80,38 @@ function nomissing(dataset::DataFrame, colnames; disallowmissing=true, view=fals
 end
 
 
-function get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity = 1)
+"""
+    get_evaluation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+
+Build the dataset used for IC/fluctuation evaluation from the original `dataset`.
+
+- **IPCW mode** (`relevant_factors.censoring_score !== nothing`): drops rows with missing
+  covariates but keeps rows where only the outcome is missing, coalescing missing Y to 0.
+  This ensures IPCW weights are non-trivial (Δ=0 zeroes the IC contribution for censored rows).
+- **Non-IPCW mode**: drops all rows with any missing relevant variable. If `prevalence` is
+  provided, additionally applies matched-controls subsampling via `get_matched_controls`.
+"""
+function get_evaluation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+    outcome = relevant_factors.outcome_mean.outcome
+    if relevant_factors.censoring_score !== nothing
+        # IPCW: keep covariate-complete rows, coalesce missing Y to 0
+        all_vars = collect(variables(relevant_factors))
+        covariate_vars = filter(v -> v != outcome, all_vars)
+        eval_data = DataFrames.select(dataset, all_vars, copycols=true)
+        dropmissing!(eval_data, covariate_vars)
+        y = eval_data[!, outcome]
+        if ismissingtype(eltype(y))
+            eval_data[!, outcome] = coalesce.(y, zero(nonmissingtype(eltype(y))))
+        end
+        disallowmissing!(eval_data)
+        return eval_data
+    end
+    # Non-IPCW: existing behavior
     nomissing_dataset = nomissing(dataset, variables(relevant_factors))
     if !isnothing(prevalence)
-        return get_matched_controls(nomissing_dataset, relevant_factors.outcome_mean.outcome; verbosity = verbosity)
-    else
-        return nomissing_dataset
+        return get_matched_controls(nomissing_dataset, outcome; verbosity=verbosity)
     end
+    return nomissing_dataset
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,7 +90,7 @@ Build the dataset used for IC/fluctuation evaluation from the original `dataset`
 
 - **IPCW mode** (`relevant_factors.censoring_score !== nothing`): drops rows with missing
   covariates but keeps rows where only the outcome is missing, coalescing missing Y to 0.
-  This ensures IPCW weights are non-trivial (Δ=0 zeroes the IC contribution for censored rows).
+  IPCW weights zero out censored rows' contributions.
 - **Non-IPCW mode**: drops all rows with any missing relevant variable. If `prevalence` is
   provided, additionally applies matched-controls subsampling via `get_matched_controls`.
 """
@@ -105,7 +105,6 @@ function get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, 
         y = eval_data[!, outcome]
         if ismissingtype(eltype(y))
             if y isa CategoricalVector
-                # For categorical Y, replace missing in-place then rebuild without Missing
                 lvls = levels(y)
                 ord = isordered(y)
                 raw = [ismissing(v) ? lvls[1] : unwrap(v) for v in y]
@@ -123,26 +122,6 @@ function get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, 
         return get_matched_controls(nomissing_dataset, outcome; verbosity=verbosity)
     end
     return nomissing_dataset
-end
-
-
-"""
-    get_fitting_dataset(dataset, relevant_factors)
-
-Build the dataset used for nuisance fitting in IPCW+CV mode. Same row filtering as
-`get_fluctuation_dataset` (drops covariate-missing rows) but keeps Y as `missing` instead of
-coalescing to 0. This way, per-fold `dropmissing` in the sample-split estimator correctly
-excludes censored rows when training Q, while G and C (whose variables don't include Y)
-train on all covariate-complete rows.
-"""
-function get_fitting_dataset(dataset, relevant_factors)
-    outcome = relevant_factors.outcome_mean.outcome
-    all_vars = collect(variables(relevant_factors))
-    covariate_vars = filter(v -> v != outcome, all_vars)
-    fit_data = DataFrames.select(dataset, all_vars, copycols=true)
-    dropmissing!(fit_data, covariate_vars)
-    disallowmissing!(fit_data, covariate_vars)
-    return fit_data
 end
 
 function indicator_values(indicators, T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,19 @@ fit_string(estimand) = string("Estimating: ", string_repr(estimand))
 
 unique_sorted_tuple(iter) = Tuple(sort(unique(Symbol(x) for x in iter)))
 
+"""
+For cross-validated and prevalence based estimators, the fluctuation dataset (see get_fluctuation_dataset)is used to fit the initial factors. 
+This is to avoid the expensive complications of:
+    - Equally distributing missing across folds
+    - Tracking sample_ids
+"""
+function choose_initial_dataset(dataset, fluctuation_dataset; train_validation_indices=nothing, prevalence=nothing, ipcw=false)
+    if !isnothing(train_validation_indices) || !isnothing(prevalence) || ipcw
+        return fluctuation_dataset
+    else
+        return dataset
+    end
+end
 
 """
 If no columns are provided, we return a single intercept column to accomodate marginal distribution fitting
@@ -119,9 +132,10 @@ function get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, 
     # Non-IPCW: existing behavior
     nomissing_dataset = nomissing(dataset, variables(relevant_factors))
     if !isnothing(prevalence)
-        return get_matched_controls(nomissing_dataset, outcome; verbosity=verbosity)
+        return get_matched_controls(nomissing_dataset, relevant_factors.outcome_mean.outcome; verbosity = verbosity)
+    else
+        return nomissing_dataset
     end
-    return nomissing_dataset
 end
 
 function indicator_values(indicators, T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,20 +29,6 @@ fit_string(estimand) = string("Estimating: ", string_repr(estimand))
 unique_sorted_tuple(iter) = Tuple(sort(unique(Symbol(x) for x in iter)))
 
 """
-For cross-validated and prevalence based estimators, the fluctuation dataset (see get_fluctuation_dataset)is used to fit the initial factors. 
-This is to avoid the expensive complications of:
-    - Equally distributing missing across folds
-    - Tracking sample_ids
-"""
-function choose_initial_dataset(dataset, fluctuation_dataset; train_validation_indices=nothing, prevalence=nothing, ipcw=false)
-    if !isnothing(train_validation_indices) || !isnothing(prevalence) || ipcw
-        return fluctuation_dataset
-    else
-        return dataset
-    end
-end
-
-"""
 If no columns are provided, we return a single intercept column to accomodate marginal distribution fitting
 Otherwise we return the required columns avoiding copying by default.
 """
@@ -64,26 +50,32 @@ censoring_indicator_name(outcome::Symbol) = Symbol(:Δ_, outcome)
 
 has_missing_outcomes(dataset, outcome::Symbol) = ismissingtype(eltype(dataset[!, outcome]))
 
-function add_censoring_indicator!(dataset, outcome::Symbol)
+function add_censoring_indicator(dataset, outcome::Symbol)
     col = dataset[!, outcome]
-    indicator_col = categorical(ifelse.(ismissing.(col), 0, 1), ordered=true)
-    dataset[!, censoring_indicator_name(outcome)] = indicator_col
-    return dataset
+    f(col) = categorical(ifelse.(ismissing.(col), 0, 1), ordered=true)
+    DataFrames.transform(dataset, outcome => f => censoring_indicator_name(outcome))
 end
 
-get_censoring_indicator(dataset, outcome::Symbol) =
-    Float64.(unwrap.(dataset[!, censoring_indicator_name(outcome)]))
-
-function compute_ipcw_weights(censoring_score, dataset, outcome::Symbol; ps_lowerbound=1e-8)
-    Δ = get_censoring_indicator(dataset, outcome)
+function compute_ipcw_weights(censoring_score, dataset; ps_lowerbound=1e-8)
+    censoring_score === nothing && return nothing
+    outcome = selectcols(dataset, [censoring_score.estimand.outcome])
+    Δ = indicator_values(Dict((1,) => 1.), outcome)
     π = likelihood(censoring_score, dataset)
     truncate!(π, ps_lowerbound)
     return Δ ./ π
 end
 
-function compute_ipcw_weights(factors, dataset; ps_lowerbound=1e-8)
-    factors.censoring_score === nothing && return nothing
-    return compute_ipcw_weights(factors.censoring_score, dataset, factors.outcome_mean.estimand.outcome; ps_lowerbound=ps_lowerbound)
+"""
+    counterfactual_censoring_covariate(censoring_score, dataset; ps_lowerbound=1e-8)
+
+Censoring factor for the counterfactual censoring intervention `Δ=1`: `1/P(Δ=1 | parents)`.
+Unlike `compute_ipcw_weights` (which uses the observed `Δ`), this sets `Δ=1`, so it is the
+factor folded into the *counterfactual* clever covariate.
+"""
+function counterfactual_censoring_covariate(censoring_score, dataset; ps_lowerbound=1e-8)
+    π = expected_value(censoring_score, dataset)
+    truncate!(π, ps_lowerbound)
+    return 1 ./ π
 end
 
 function nomissing(dataset::DataFrame, colnames; disallowmissing=true, view=false, copycols=false)
@@ -97,46 +89,78 @@ end
 
 
 """
-    get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+    get_initial_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
 
-Build the dataset used for IC/fluctuation evaluation from the original `dataset`.
+Build the single dataset used for both fold construction and nuisance fitting. Keeping these on
+the same rows means the CV fold indices stay aligned with the fluctuation dataset (which is these
+same rows with missing outcomes coalesced, see `get_fluctuation_dataset`).
 
-- **IPCW mode** (`relevant_factors.censoring_score !== nothing`): drops rows with missing
-  covariates but keeps rows where only the outcome is missing, coalescing missing Y to 0.
-  IPCW weights zero out censored rows' contributions.
+- **IPCW mode** (`relevant_factors.censoring_score !== nothing`): keeps every row. Each nuisance
+  estimator drops the rows it can't use (missing among *its own* variables) when it fits, so the
+  propensity/censoring models are not penalised by rows another model happens to be missing. The
+  covariate-complete rows needed to predict *all* nuisances are selected separately by
+  `get_fluctuation_dataset`; under CV the fold indices are realigned to that subset via
+  `align_to_rows` in the estimators.
 - **Non-IPCW mode**: drops all rows with any missing relevant variable. If `prevalence` is
   provided, additionally applies matched-controls subsampling via `get_matched_controls`.
 """
-function get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+function get_initial_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+    relevant_factors.censoring_score !== nothing && return dataset
     outcome = relevant_factors.outcome_mean.outcome
-    if relevant_factors.censoring_score !== nothing
-        # IPCW: keep covariate-complete rows, coalesce missing Y to 0
-        all_vars = collect(variables(relevant_factors))
-        covariate_vars = filter(v -> v != outcome, all_vars)
-        eval_data = DataFrames.select(dataset, all_vars, copycols=true)
-        dropmissing!(eval_data, covariate_vars)
-        y = eval_data[!, outcome]
-        if ismissingtype(eltype(y))
-            if y isa CategoricalVector
-                lvls = levels(y)
-                ord = isordered(y)
-                raw = [ismissing(v) ? lvls[1] : unwrap(v) for v in y]
-                eval_data[!, outcome] = categorical(raw, levels=lvls, ordered=ord)
-            else
-                eval_data[!, outcome] = coalesce.(y, zero(nonmissingtype(eltype(y))))
-            end
-        end
-        disallowmissing!(eval_data)
-        return eval_data
-    end
-    # Non-IPCW: existing behavior
     nomissing_dataset = nomissing(dataset, variables(relevant_factors))
-    if !isnothing(prevalence)
-        return get_matched_controls(nomissing_dataset, relevant_factors.outcome_mean.outcome; verbosity = verbosity)
-    else
-        return nomissing_dataset
-    end
+    return isnothing(prevalence) ? nomissing_dataset : get_matched_controls(nomissing_dataset, outcome; verbosity=verbosity)
 end
+
+"""
+    get_fluctuation_dataset(initial_dataset, relevant_factors)
+
+Derive the dataset on which all nuisances are predicted to fit the fluctuation (epsilon) and
+evaluate the gradient. Under IPCW it (1) drops rows missing any covariate — every nuisance
+(Q, G, π) must be predictable on every row, which coalescing the outcome alone does not
+guarantee — and (2) coalesces missing outcomes to 0 so the fluctuation GLM has a numeric target;
+censored rows (Δ=0) are zeroed out by the clever covariate, so the imputed value is irrelevant.
+Outside IPCW the initial dataset is already complete and is returned unchanged.
+
+The kept rows are those flagged by `fluctuation_row_mask`; CV fold indices are realigned to this
+same subset via `align_to_rows`, so the two stay consistent.
+"""
+function get_fluctuation_dataset(initial_dataset, relevant_factors)
+    relevant_factors.censoring_score === nothing && return initial_dataset
+    outcome = relevant_factors.outcome_mean.outcome
+    fluctuation_dataset = initial_dataset[fluctuation_row_mask(initial_dataset, relevant_factors), :]
+    fluctuation_dataset[!, outcome] = coalesce_outcome(fluctuation_dataset[!, outcome])
+    return fluctuation_dataset
+end
+
+"""
+    fluctuation_row_mask(initial_dataset, relevant_factors)
+
+Boolean mask (over the full initial-dataset rows) selecting the covariate-complete rows that make
+up the fluctuation dataset — every nuisance must be predictable on these rows. Single source of
+truth shared by `get_fluctuation_dataset` and the CV fold realignment in the estimators.
+"""
+function fluctuation_row_mask(initial_dataset, relevant_factors)
+    outcome = relevant_factors.outcome_mean.outcome
+    covariate_vars = filter(!=(outcome), collect(variables(relevant_factors)))
+    return completecases(initial_dataset, covariate_vars)
+end
+
+"""
+    coalesce_outcome(y)
+
+Replace missing outcome values with a placeholder (first level for a categorical, `zero` for a
+numeric) and return a column with a non-missing element type.
+"""
+function coalesce_outcome(y)
+    ismissingtype(eltype(y)) || return y
+    if y isa CategoricalVector
+        lvls = levels(y)
+        raw = [ismissing(v) ? lvls[1] : unwrap(v) for v in y]
+        return categorical(raw, levels=lvls, ordered=isordered(y))
+    end
+    return coalesce.(y, zero(nonmissingtype(eltype(y))))
+end
+
 
 function indicator_values(indicators, T)
     indic = zeros(Float64, nrows(T))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,6 +61,29 @@ end
 
 ismissingtype(T) = nonmissingtype(T) !== T
 
+censoring_indicator_name(outcome::Symbol) = Symbol(:Δ_, outcome)
+
+has_missing_outcomes(dataset, outcome::Symbol) = ismissingtype(eltype(dataset[!, outcome]))
+
+function add_censoring_indicator!(dataset, outcome::Symbol)
+    col = dataset[!, outcome]
+    indicator_col = categorical(ifelse.(ismissing.(col), 0, 1), ordered=true)
+    dataset[!, censoring_indicator_name(outcome)] = indicator_col
+    return dataset
+end
+
+get_censoring_indicator(dataset, outcome::Symbol) =
+    Float64.(unwrap.(dataset[!, censoring_indicator_name(outcome)]))
+
+function compute_ipcw_weights(factors, dataset; ps_lowerbound=1e-8)
+    factors.censoring_score === nothing && return nothing
+    outcome = factors.outcome_mean.estimand.outcome
+    Δ = get_censoring_indicator(dataset, outcome)
+    π = likelihood(factors.censoring_score, dataset)
+    truncate!(π, ps_lowerbound)
+    return Δ ./ π
+end
+
 function nomissing(dataset::DataFrame, colnames; disallowmissing=true, view=false, copycols=false)
     subdataset = TMLE.selectcols(dataset, colnames, copycols=copycols)
     return if all(!ismissingtype(eltype(c)) for c in eachcol(subdataset))
@@ -129,15 +152,20 @@ function get_matched_controls(dataset, outcome; verbosity = 1)
 end
 
 """
-    default_models(;Q_binary=LinearBinaryClassifier(), Q_continuous=LinearRegressor(), G=LinearBinaryClassifier()) = (
+    default_models(;Q_binary=LinearBinaryClassifier(), Q_continuous=LinearRegressor(), G=LinearBinaryClassifier(), C=LinearBinaryClassifier())
 
 Create a Dictionary containing default models to be used by downstream estimators. 
 Each provided model is prepended (in a `MLJ.Pipeline`) with an `MLJ.ContinuousEncoder`.
 
 By default:
-    - Q_binary is a LinearBinaryClassifier
-    - Q_continuous is a LinearRegressor
-    - G is a LinearBinaryClassifier
+    - Q_binary is a LinearBinaryClassifier (binary outcome mean)
+    - Q_continuous is a LinearRegressor (continuous outcome mean)
+    - G is a LinearBinaryClassifier (propensity score)
+    - C is a LinearBinaryClassifier (censoring score for IPCW)
+
+The `C` model is used when outcome missingness triggers IPCW (see `Tmle` / `Ose`). It models
+`P(Δ=1 | W)`, the probability of observing the outcome given covariates. You can also assign
+a model to the censoring indicator name directly (e.g. `Symbol("Δ_Y") => your_model`).
 
 # Example
 
@@ -152,10 +180,11 @@ models = default_models(
 ```
 
 """
-default_models(;Q_binary=LinearBinaryClassifier(), Q_continuous=LinearRegressor(), G=LinearBinaryClassifier(), kwargs...) = Dict(
+default_models(;Q_binary=LinearBinaryClassifier(), Q_continuous=LinearRegressor(), G=LinearBinaryClassifier(), C=LinearBinaryClassifier(), kwargs...) = Dict(
     :Q_binary_default     => with_encoder(Q_binary),
     :Q_continuous_default => with_encoder(Q_continuous),
     :G_default            => with_encoder(G),
+    :C_default            => with_encoder(C),
     (key => with_encoder(val) for (key, val) in kwargs)...
 )
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -340,9 +340,12 @@ with_encoder(model; encoder=ContinuousEncoder(drop_last=true, one_hot_ordered_fa
 
 Evaluate if the dataset is suitable for the estimand Ψ.
 """
-function check_inputs(Ψ, dataset, prevalence)
+function check_inputs(Ψ, dataset, prevalence, ipcw)
     check_treatment_levels(Ψ, dataset)
     !isnothing(prevalence) && ccw_check(dataset, Ψ.outcome)
+    if ipcw && prevalence !== nothing
+        throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
+    end
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,13 +61,16 @@ end
 get_censoring_indicator(dataset, outcome::Symbol) =
     Float64.(unwrap.(dataset[!, censoring_indicator_name(outcome)]))
 
-function compute_ipcw_weights(factors, dataset; ps_lowerbound=1e-8)
-    factors.censoring_score === nothing && return nothing
-    outcome = factors.outcome_mean.estimand.outcome
+function compute_ipcw_weights(censoring_score, dataset, outcome::Symbol; ps_lowerbound=1e-8)
     Δ = get_censoring_indicator(dataset, outcome)
-    π = likelihood(factors.censoring_score, dataset)
+    π = likelihood(censoring_score, dataset)
     truncate!(π, ps_lowerbound)
     return Δ ./ π
+end
+
+function compute_ipcw_weights(factors, dataset; ps_lowerbound=1e-8)
+    factors.censoring_score === nothing && return nothing
+    return compute_ipcw_weights(factors.censoring_score, dataset, factors.outcome_mean.estimand.outcome; ps_lowerbound=ps_lowerbound)
 end
 
 function nomissing(dataset::DataFrame, colnames; disallowmissing=true, view=false, copycols=false)
@@ -81,7 +84,7 @@ end
 
 
 """
-    get_evaluation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+    get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
 
 Build the dataset used for IC/fluctuation evaluation from the original `dataset`.
 
@@ -91,7 +94,7 @@ Build the dataset used for IC/fluctuation evaluation from the original `dataset`
 - **Non-IPCW mode**: drops all rows with any missing relevant variable. If `prevalence` is
   provided, additionally applies matched-controls subsampling via `get_matched_controls`.
 """
-function get_evaluation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
+function get_fluctuation_dataset(dataset, relevant_factors; prevalence=nothing, verbosity=1)
     outcome = relevant_factors.outcome_mean.outcome
     if relevant_factors.censoring_score !== nothing
         # IPCW: keep covariate-complete rows, coalesce missing Y to 0
@@ -101,7 +104,15 @@ function get_evaluation_dataset(dataset, relevant_factors; prevalence=nothing, v
         dropmissing!(eval_data, covariate_vars)
         y = eval_data[!, outcome]
         if ismissingtype(eltype(y))
-            eval_data[!, outcome] = coalesce.(y, zero(nonmissingtype(eltype(y))))
+            if y isa CategoricalVector
+                # For categorical Y, replace missing in-place then rebuild without Missing
+                lvls = levels(y)
+                ord = isordered(y)
+                raw = [ismissing(v) ? lvls[1] : unwrap(v) for v in y]
+                eval_data[!, outcome] = categorical(raw, levels=lvls, ordered=ord)
+            else
+                eval_data[!, outcome] = coalesce.(y, zero(nonmissingtype(eltype(y))))
+            end
         end
         disallowmissing!(eval_data)
         return eval_data
@@ -114,6 +125,25 @@ function get_evaluation_dataset(dataset, relevant_factors; prevalence=nothing, v
     return nomissing_dataset
 end
 
+
+"""
+    get_fitting_dataset(dataset, relevant_factors)
+
+Build the dataset used for nuisance fitting in IPCW+CV mode. Same row filtering as
+`get_fluctuation_dataset` (drops covariate-missing rows) but keeps Y as `missing` instead of
+coalescing to 0. This way, per-fold `dropmissing` in the sample-split estimator correctly
+excludes censored rows when training Q, while G and C (whose variables don't include Y)
+train on all covariate-complete rows.
+"""
+function get_fitting_dataset(dataset, relevant_factors)
+    outcome = relevant_factors.outcome_mean.outcome
+    all_vars = collect(variables(relevant_factors))
+    covariate_vars = filter(v -> v != outcome, all_vars)
+    fit_data = DataFrames.select(dataset, all_vars, copycols=true)
+    dropmissing!(fit_data, covariate_vars)
+    disallowmissing!(fit_data, covariate_vars)
+    return fit_data
+end
 
 function indicator_values(indicators, T)
     indic = zeros(Float64, nrows(T))

--- a/test/counterfactual_mean_based/clever_covariate.jl
+++ b/test/counterfactual_mean_based/clever_covariate.jl
@@ -80,7 +80,6 @@ end
         dataset,
         verbosity=0
     )
-
     ps_lowerbound = 1e-8
     weighted_fluctuation = false
 

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -38,45 +38,6 @@ include(joinpath(dirname(dirname(pathof(TMLE))), "test", "helper_fns.jl"))
     @test TMLE.is_binary(df, :Δ_Y)
 end
 
-@testset "CMRelevantFactors with censoring_score" begin
-    om = TMLE.ConditionalDistribution(:Y, (:T, :W))
-    ps = TMLE.ConditionalDistribution(:T, (:W,))
-    cs = TMLE.ConditionalDistribution(:Δ_Y, (:T, :W))
-
-    # Without censoring
-    rf = TMLE.CMRelevantFactors(om, (ps,))
-    @test rf.censoring_score === nothing
-
-    # With censoring
-    rf_ipcw = TMLE.CMRelevantFactors(om, (ps,), cs)
-    @test rf_ipcw.censoring_score === cs
-    @test :Δ_Y ∈ TMLE.variables(rf_ipcw)
-
-    # Keyword constructor
-    rf_kw = TMLE.CMRelevantFactors(outcome_mean=om, propensity_score=(ps,), censoring_score=cs)
-    @test rf_kw == rf_ipcw
-end
-
-@testset "get_relevant_factors with IPCW" begin
-    # No dataset → no censoring
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
-    rf = TMLE.get_relevant_factors(Ψ)
-    @test rf.censoring_score === nothing
-
-    # ipcw=false → no censoring
-    rf = TMLE.get_relevant_factors(Ψ; ipcw=false)
-    @test rf.censoring_score === nothing
-
-    # ipcw=true → censoring activated
-    rf = TMLE.get_relevant_factors(Ψ; ipcw=true)
-    @test rf.censoring_score !== nothing
-    @test rf.censoring_score.outcome == :Δ_Y
-end
-
 """
 Generate a continuous outcome ATE problem with MAR missingness.
 Missingness depends on W (confounders) creating a MAR pattern.
@@ -104,7 +65,7 @@ function ate_with_mar_missingness(;n=2000)
     return dataset, ATE_true
 end
 
-@testset "IPCW OSE" begin
+@testset "IPCW OSE and TMLE" begin
     dataset, ATE_true = ate_with_mar_missingness(n=5000)
     Ψ = ATE(
         outcome=:Y,
@@ -114,15 +75,7 @@ end
     ose = Ose()
     result, _ = ose(Ψ, dataset; verbosity=0)
     test_coverage(result, ATE_true)
-end
 
-@testset "IPCW TMLE" begin
-    dataset, ATE_true = ate_with_mar_missingness(n=5000)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
     tmle = Tmle()
     result, _ = tmle(Ψ, dataset; verbosity=0)
     test_coverage(result, ATE_true)

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -32,6 +32,10 @@ include(joinpath(dirname(dirname(pathof(TMLE))), "test", "helper_fns.jl"))
     Δ = df[!, :Δ_Y]
     @test Δ isa CategoricalVector
     @test unwrap.(Δ) == [1, 0, 1, 0, 1]
+
+    # The censoring indicator must register as binary so nuisance model selection treats it as a
+    # classification target (see `is_binary` in nuisance_estimators.jl).
+    @test TMLE.is_binary(df, :Δ_Y)
 end
 
 @testset "CMRelevantFactors with censoring_score" begin

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -207,6 +207,41 @@ end
     test_coverage(result, 2.0)
 end
 
+@testset "IPCW + CV throws ArgumentError" begin
+    dataset, _ = ate_with_mcar_missingness(n=200)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    # TMLE with CV + IPCW
+    tmle_cv = Tmle(resampling=CV(nfolds=3))
+    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla TMLE (resampling=nothing) instead.") tmle_cv(Ψ, dataset; verbosity=0)
+
+    # OSE with CV + IPCW
+    dataset2, _ = ate_with_mcar_missingness(n=200)
+    ose_cv = Ose(resampling=CV(nfolds=3))
+    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla OSE (resampling=nothing) instead.") ose_cv(Ψ, dataset2; verbosity=0)
+end
+
+@testset "IPCW + prevalence throws ArgumentError" begin
+    dataset, _ = ate_with_mcar_missingness(n=200)
+    # Make outcome binary for prevalence compatibility
+    dataset.Y = Vector{Union{Missing, Float64}}([ismissing(y) ? missing : Float64(y > 0) for y in dataset.Y])
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    tmle_prev = Tmle(prevalence=0.1)
+    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction.") tmle_prev(Ψ, dataset; verbosity=0)
+
+    dataset2, _ = ate_with_mcar_missingness(n=200)
+    dataset2.Y = Vector{Union{Missing, Float64}}([ismissing(y) ? missing : Float64(y > 0) for y in dataset2.Y])
+    ose_prev = Ose(prevalence=0.1)
+    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction.") ose_prev(Ψ, dataset2; verbosity=0)
+end
+
 end
 
 true

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -156,21 +156,6 @@ end
     test_coverage(result, 2.0)
 end
 
-@testset "IPCW + prevalence throws ArgumentError" begin
-    dataset, _ = ate_with_mar_missingness(n=200)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
-    tmle_prev = Tmle(prevalence=0.1)
-    @test_throws ArgumentError tmle_prev(Ψ, dataset; verbosity=0)
-
-    dataset2, _ = ate_with_mar_missingness(n=200)
-    ose_prev = Ose(prevalence=0.1)
-    @test_throws ArgumentError ose_prev(Ψ, dataset2; verbosity=0)
-end
-
 end
 
 true

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -10,9 +10,7 @@ using MLJBase
 using LogExpFunctions
 using TMLE
 
-PKG_DIR = pkgdir(TMLE)
-TEST_DIR = joinpath(PKG_DIR, "test")
-include(joinpath(TEST_DIR, "helper_fns.jl"))
+include(joinpath(dirname(dirname(pathof(TMLE))), "test", "helper_fns.jl"))
 
 @testset "Censoring indicator utilities" begin
     # Test censoring_indicator_name
@@ -110,56 +108,7 @@ function ate_with_mar_missingness(;n=2000)
     return dataset, ATE_true
 end
 
-"""
-Generate a continuous outcome ATE problem with MCAR missingness.
-"""
-function ate_with_mcar_missingness(;n=2000)
-    rng = StableRNG(42)
-    W = randn(rng, n)
-    T = rand(rng, n) .< LogExpFunctions.logistic.(0.5 .* W)
-    # True ATE = 2
-    Y = 2.0 .* T .+ W .+ 0.5 .* randn(rng, n)
-    ATE_true = 2.0
-
-    dataset = DataFrame(
-        W = W,
-        T = categorical(Int.(T)),
-        Y = Vector{Union{Missing, Float64}}(Y)
-    )
-    # MCAR: 20% random missingness
-    for i in 1:n
-        if rand(rng) < 0.2
-            dataset.Y[i] = missing
-        end
-    end
-    return dataset, ATE_true
-end
-
-@testset "IPCW OSE: MCAR missingness" begin
-    dataset, ATE_true = ate_with_mcar_missingness(n=5000)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
-    ose = Ose()
-    result, _ = ose(Ψ, dataset; verbosity=0)
-    test_coverage(result, ATE_true)
-end
-
-@testset "IPCW TMLE: MCAR missingness" begin
-    dataset, ATE_true = ate_with_mcar_missingness(n=5000)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
-    tmle = Tmle()
-    result, _ = tmle(Ψ, dataset; verbosity=0)
-    test_coverage(result, ATE_true)
-end
-
-@testset "IPCW OSE: MAR missingness" begin
+@testset "IPCW OSE" begin
     dataset, ATE_true = ate_with_mar_missingness(n=5000)
     Ψ = ATE(
         outcome=:Y,
@@ -171,7 +120,7 @@ end
     test_coverage(result, ATE_true)
 end
 
-@testset "IPCW TMLE: MAR missingness" begin
+@testset "IPCW TMLE" begin
     dataset, ATE_true = ate_with_mar_missingness(n=5000)
     Ψ = ATE(
         outcome=:Y,
@@ -207,39 +156,19 @@ end
     test_coverage(result, 2.0)
 end
 
-@testset "IPCW + CV throws ArgumentError" begin
-    dataset, _ = ate_with_mcar_missingness(n=200)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
-    # TMLE with CV + IPCW
-    tmle_cv = Tmle(resampling=CV(nfolds=3))
-    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla TMLE (resampling=nothing) instead.") tmle_cv(Ψ, dataset; verbosity=0)
-
-    # OSE with CV + IPCW
-    dataset2, _ = ate_with_mcar_missingness(n=200)
-    ose_cv = Ose(resampling=CV(nfolds=3))
-    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with cross-validation. Use vanilla OSE (resampling=nothing) instead.") ose_cv(Ψ, dataset2; verbosity=0)
-end
-
 @testset "IPCW + prevalence throws ArgumentError" begin
-    dataset, _ = ate_with_mcar_missingness(n=200)
-    # Make outcome binary for prevalence compatibility
-    dataset.Y = Vector{Union{Missing, Float64}}([ismissing(y) ? missing : Float64(y > 0) for y in dataset.Y])
+    dataset, _ = ate_with_mar_missingness(n=200)
     Ψ = ATE(
         outcome=:Y,
         treatment_values=(T=(case=1, control=0),),
         treatment_confounders=(T=[:W],)
     )
     tmle_prev = Tmle(prevalence=0.1)
-    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction.") tmle_prev(Ψ, dataset; verbosity=0)
+    @test_throws ArgumentError tmle_prev(Ψ, dataset; verbosity=0)
 
-    dataset2, _ = ate_with_mcar_missingness(n=200)
-    dataset2.Y = Vector{Union{Missing, Float64}}([ismissing(y) ? missing : Float64(y > 0) for y in dataset2.Y])
+    dataset2, _ = ate_with_mar_missingness(n=200)
     ose_prev = Ose(prevalence=0.1)
-    @test_throws ArgumentError("IPCW (missing outcomes) is not supported with prevalence correction.") ose_prev(Ψ, dataset2; verbosity=0)
+    @test_throws ArgumentError ose_prev(Ψ, dataset2; verbosity=0)
 end
 
 end

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -25,18 +25,13 @@ include(joinpath(dirname(dirname(pathof(TMLE))), "test", "helper_fns.jl"))
     @test TMLE.has_missing_outcomes(df, :Y) == true
     @test TMLE.has_missing_outcomes(df, :X) == false
 
-    # Test add_censoring_indicator!
+    # Test add_censoring_indicator
     df = DataFrame(Y = Union{Missing, Float64}[1.0, missing, 3.0, missing, 5.0])
-    TMLE.add_censoring_indicator!(df, :Y)
+    df = TMLE.add_censoring_indicator(df, :Y)
     @test hasproperty(df, :Δ_Y)
     Δ = df[!, :Δ_Y]
     @test Δ isa CategoricalVector
     @test unwrap.(Δ) == [1, 0, 1, 0, 1]
-
-    # Test get_censoring_indicator
-    Δ_float = TMLE.get_censoring_indicator(df, :Y)
-    @test Δ_float == [1.0, 0.0, 1.0, 0.0, 1.0]
-    @test eltype(Δ_float) == Float64
 end
 
 @testset "CMRelevantFactors with censoring_score" begin
@@ -68,15 +63,12 @@ end
     rf = TMLE.get_relevant_factors(Ψ)
     @test rf.censoring_score === nothing
 
-    # Dataset without missing → no censoring
-    df = DataFrame(Y=randn(10), T=categorical(rand(0:1, 10)), W=randn(10))
-    rf = TMLE.get_relevant_factors(Ψ; dataset=df)
+    # ipcw=false → no censoring
+    rf = TMLE.get_relevant_factors(Ψ; ipcw=false)
     @test rf.censoring_score === nothing
 
-    # Dataset with missing outcome → censoring activated
-    allowmissing!(df, :Y)
-    df.Y[1] = missing
-    rf = TMLE.get_relevant_factors(Ψ; dataset=df)
+    # ipcw=true → censoring activated
+    rf = TMLE.get_relevant_factors(Ψ; ipcw=true)
     @test rf.censoring_score !== nothing
     @test rf.censoring_score.outcome == :Δ_Y
 end
@@ -132,28 +124,57 @@ end
     test_coverage(result, ATE_true)
 end
 
-@testset "No missingness: censoring_score is nothing" begin
-    # When no missing data, IPCW should not be triggered
-    rng = StableRNG(123)
-    n = 500
-    W = randn(rng, n)
-    T = categorical(Int.(rand(rng, n) .< 0.5))
-    Y = 2.0 .* Float64.(unwrap.(T)) .+ W .+ randn(rng, n)
-    dataset = DataFrame(W=W, T=T, Y=Y)
+"""
+Generate a continuous outcome ATE problem with MAR missing *outcomes* AND some missing
+*covariates*. Both W₁ and W₂ confound; W₂ is missing at random in a fraction of rows.
+"""
+function ate_with_missing_covariates(;n=5000)
+    rng = StableRNG(42)
+    W₁ = randn(rng, n)
+    W₂ = randn(rng, n)
+    T = rand(rng, n) .< LogExpFunctions.logistic.(0.5 .* W₁ .+ 0.3 .* W₂)
+    Y = 2.0 .* T .+ W₁ .+ W₂ .+ 0.5 .* randn(rng, n)
+    ATE_true = 2.0
 
+    dataset = DataFrame(
+        W₁ = W₁,
+        W₂ = Vector{Union{Missing, Float64}}(W₂),
+        T = categorical(Int.(T)),
+        Y = Vector{Union{Missing, Float64}}(Y)
+    )
+    # MAR missing outcomes (depend on W₁)
+    p_missing_Y = LogExpFunctions.logistic.(-1.0 .+ 0.8 .* W₁)
+    # Missing covariate W₂ (depend on W₁, independent of the Y-missingness draw)
+    p_missing_W₂ = LogExpFunctions.logistic.(-1.5 .+ 0.5 .* W₁)
+    for i in 1:n
+        rand(rng) < p_missing_Y[i] && (dataset.Y[i] = missing)
+        rand(rng) < p_missing_W₂[i] && (dataset.W₂[i] = missing)
+    end
+    return dataset, ATE_true
+end
+
+@testset "CV-IPCW TMLE with missing covariates" begin
+    dataset, ATE_true = ate_with_missing_covariates(n=5000)
     Ψ = ATE(
         outcome=:Y,
         treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
+        treatment_confounders=(T=[:W₁, :W₂],)
     )
-    tmle = Tmle()
-    result, cache = tmle(Ψ, dataset; verbosity=0)
-    # Verify censoring_score is nothing
-    targeted_factors = cache[:targeted_factors]
-    @test targeted_factors.censoring_score === nothing
-    # Verify no censoring indicator column added
-    @test !hasproperty(dataset, :Δ_Y)
-    test_coverage(result, 2.0)
+    tmle = Tmle(resampling=CV(nfolds=3))
+    result, _ = tmle(Ψ, dataset; verbosity=0)
+    test_coverage(result, ATE_true)
+end
+
+@testset "CV-IPCW OSE with missing covariates" begin
+    dataset, ATE_true = ate_with_missing_covariates(n=5000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W₁, :W₂],)
+    )
+    ose = Ose(resampling=CV(nfolds=3))
+    result, _ = ose(Ψ, dataset; verbosity=0)
+    test_coverage(result, ATE_true)
 end
 
 end

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -1,0 +1,212 @@
+module TestIPCW
+
+using Test
+using StableRNGs
+using Random
+using Distributions
+using DataFrames
+using CategoricalArrays
+using MLJBase
+using LogExpFunctions
+using TMLE
+
+PKG_DIR = pkgdir(TMLE)
+TEST_DIR = joinpath(PKG_DIR, "test")
+include(joinpath(TEST_DIR, "helper_fns.jl"))
+
+@testset "Censoring indicator utilities" begin
+    # Test censoring_indicator_name
+    @test TMLE.censoring_indicator_name(:Y) == :Δ_Y
+    @test TMLE.censoring_indicator_name(:outcome) == :Δ_outcome
+
+    # Test has_missing_outcomes
+    df = DataFrame(Y = [1.0, 2.0, 3.0], X = [1, 2, 3])
+    @test TMLE.has_missing_outcomes(df, :Y) == false
+    allowmissing!(df, :Y)
+    df.Y[2] = missing
+    @test TMLE.has_missing_outcomes(df, :Y) == true
+    @test TMLE.has_missing_outcomes(df, :X) == false
+
+    # Test add_censoring_indicator!
+    df = DataFrame(Y = Union{Missing, Float64}[1.0, missing, 3.0, missing, 5.0])
+    TMLE.add_censoring_indicator!(df, :Y)
+    @test hasproperty(df, :Δ_Y)
+    Δ = df[!, :Δ_Y]
+    @test Δ isa CategoricalVector
+    @test unwrap.(Δ) == [1, 0, 1, 0, 1]
+
+    # Test get_censoring_indicator
+    Δ_float = TMLE.get_censoring_indicator(df, :Y)
+    @test Δ_float == [1.0, 0.0, 1.0, 0.0, 1.0]
+    @test eltype(Δ_float) == Float64
+end
+
+@testset "CMRelevantFactors with censoring_score" begin
+    om = TMLE.ConditionalDistribution(:Y, (:T, :W))
+    ps = TMLE.ConditionalDistribution(:T, (:W,))
+    cs = TMLE.ConditionalDistribution(:Δ_Y, (:T, :W))
+
+    # Without censoring
+    rf = TMLE.CMRelevantFactors(om, (ps,))
+    @test rf.censoring_score === nothing
+
+    # With censoring
+    rf_ipcw = TMLE.CMRelevantFactors(om, (ps,), cs)
+    @test rf_ipcw.censoring_score === cs
+    @test :Δ_Y ∈ TMLE.variables(rf_ipcw)
+
+    # Keyword constructor
+    rf_kw = TMLE.CMRelevantFactors(outcome_mean=om, propensity_score=(ps,), censoring_score=cs)
+    @test rf_kw == rf_ipcw
+end
+
+@testset "get_relevant_factors with IPCW" begin
+    # No dataset → no censoring
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    rf = TMLE.get_relevant_factors(Ψ)
+    @test rf.censoring_score === nothing
+
+    # Dataset without missing → no censoring
+    df = DataFrame(Y=randn(10), T=categorical(rand(0:1, 10)), W=randn(10))
+    rf = TMLE.get_relevant_factors(Ψ; dataset=df)
+    @test rf.censoring_score === nothing
+
+    # Dataset with missing outcome → censoring activated
+    allowmissing!(df, :Y)
+    df.Y[1] = missing
+    rf = TMLE.get_relevant_factors(Ψ; dataset=df)
+    @test rf.censoring_score !== nothing
+    @test rf.censoring_score.outcome == :Δ_Y
+end
+
+"""
+Generate a continuous outcome ATE problem with MAR missingness.
+Missingness depends on W (confounders) creating a MAR pattern.
+"""
+function ate_with_mar_missingness(;n=2000)
+    rng = StableRNG(42)
+    W = randn(rng, n)
+    T = rand(rng, n) .< LogExpFunctions.logistic.(0.5 .* W)
+    # True ATE = 2
+    Y = 2.0 .* T .+ W .+ 0.5 .* randn(rng, n)
+    ATE_true = 2.0
+
+    dataset = DataFrame(
+        W = W,
+        T = categorical(Int.(T)),
+        Y = Vector{Union{Missing, Float64}}(Y)
+    )
+    # MAR missingness: P(missing | W) depends on W
+    p_missing = LogExpFunctions.logistic.(-1.0 .+ 0.8 .* W)
+    for i in 1:n
+        if rand(rng) < p_missing[i]
+            dataset.Y[i] = missing
+        end
+    end
+    return dataset, ATE_true
+end
+
+"""
+Generate a continuous outcome ATE problem with MCAR missingness.
+"""
+function ate_with_mcar_missingness(;n=2000)
+    rng = StableRNG(42)
+    W = randn(rng, n)
+    T = rand(rng, n) .< LogExpFunctions.logistic.(0.5 .* W)
+    # True ATE = 2
+    Y = 2.0 .* T .+ W .+ 0.5 .* randn(rng, n)
+    ATE_true = 2.0
+
+    dataset = DataFrame(
+        W = W,
+        T = categorical(Int.(T)),
+        Y = Vector{Union{Missing, Float64}}(Y)
+    )
+    # MCAR: 20% random missingness
+    for i in 1:n
+        if rand(rng) < 0.2
+            dataset.Y[i] = missing
+        end
+    end
+    return dataset, ATE_true
+end
+
+@testset "IPCW OSE: MCAR missingness" begin
+    dataset, ATE_true = ate_with_mcar_missingness(n=5000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    ose = Ose()
+    result, _ = ose(Ψ, dataset; verbosity=0)
+    test_coverage(result, ATE_true)
+end
+
+@testset "IPCW TMLE: MCAR missingness" begin
+    dataset, ATE_true = ate_with_mcar_missingness(n=5000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    tmle = Tmle()
+    result, _ = tmle(Ψ, dataset; verbosity=0)
+    test_coverage(result, ATE_true)
+end
+
+@testset "IPCW OSE: MAR missingness" begin
+    dataset, ATE_true = ate_with_mar_missingness(n=5000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    ose = Ose()
+    result, _ = ose(Ψ, dataset; verbosity=0)
+    test_coverage(result, ATE_true)
+end
+
+@testset "IPCW TMLE: MAR missingness" begin
+    dataset, ATE_true = ate_with_mar_missingness(n=5000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    tmle = Tmle()
+    result, _ = tmle(Ψ, dataset; verbosity=0)
+    test_coverage(result, ATE_true)
+end
+
+@testset "No missingness: censoring_score is nothing" begin
+    # When no missing data, IPCW should not be triggered
+    rng = StableRNG(123)
+    n = 500
+    W = randn(rng, n)
+    T = categorical(Int.(rand(rng, n) .< 0.5))
+    Y = 2.0 .* Float64.(unwrap.(T)) .+ W .+ randn(rng, n)
+    dataset = DataFrame(W=W, T=T, Y=Y)
+
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    tmle = Tmle()
+    result, cache = tmle(Ψ, dataset; verbosity=0)
+    # Verify censoring_score is nothing
+    targeted_factors = cache[:targeted_factors]
+    @test targeted_factors.censoring_score === nothing
+    # Verify no censoring indicator column added
+    @test !hasproperty(dataset, :Δ_Y)
+    test_coverage(result, 2.0)
+end
+
+end
+
+true

--- a/test/estimands.jl
+++ b/test/estimands.jl
@@ -30,6 +30,28 @@ end
     @test TMLE.variables(η) == (:Y, :T, :W, :T₁, :W₁, :T₂, :W₂₁, :W₂₂)
     # Test string representation
     @test TMLE.string_repr(η) == "Relevant Factors: \n- P₀(Y | T, W)\n- P₀(T₁ | W₁)\n- P₀(T₂ | W₂₁, W₂₂)"
+
+    η = TMLE.CMRelevantFactors(
+        outcome_mean=TMLE.ExpectedValue(:Y, [:T, :W]),
+        propensity_score=TMLE.ConditionalDistribution(:T, [:W]),
+        censoring_score=TMLE.ConditionalDistribution(:Δ_Y, (:T, :W))
+    )
+    @test :Δ_Y ∈ TMLE.variables(η)
+end
+
+@testset "get_relevant_factors with IPCW" begin
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    rf = TMLE.get_relevant_factors(Ψ)
+    @test rf.censoring_score === nothing
+
+    # ipcw=true → censoring activated
+    rf = TMLE.get_relevant_factors(Ψ; ipcw=true)
+    @test rf.censoring_score !== nothing
+    @test rf.censoring_score.outcome == :Δ_Y
 end
 
 @testset "Test JointEstimand and ComposedEstimand" begin

--- a/test/helper_fns.jl
+++ b/test/helper_fns.jl
@@ -24,9 +24,8 @@ increase risk more than tol
 function test_fluct_decreases_risk(cache; atol=1e-6)
     fluctuated_mean_machine = cache[:targeted_factors].outcome_mean.machine
     initial_mean_machine = fluctuated_mean_machine.model.initial_factors.outcome_mean.machine
-    X = fluctuated_mean_machine.data[1]
     y = fluctuated_mean_machine.data[2]
-    initial_risk = risk(MLJBase.predict(initial_mean_machine, X), y)
+    initial_risk = risk(MLJBase.predict(initial_mean_machine), y)
     fluct_risk = risk(MLJBase.predict(fluctuated_mean_machine), y)
     @test initial_risk >= fluct_risk || isapprox(initial_risk, fluct_risk, atol=atol)
 end

--- a/test/helper_fns.jl
+++ b/test/helper_fns.jl
@@ -24,8 +24,9 @@ increase risk more than tol
 function test_fluct_decreases_risk(cache; atol=1e-6)
     fluctuated_mean_machine = cache[:targeted_factors].outcome_mean.machine
     initial_mean_machine = fluctuated_mean_machine.model.initial_factors.outcome_mean.machine
+    X = fluctuated_mean_machine.data[1]
     y = fluctuated_mean_machine.data[2]
-    initial_risk = risk(MLJBase.predict(initial_mean_machine), y)
+    initial_risk = risk(MLJBase.predict(initial_mean_machine, X), y)
     fluct_risk = risk(MLJBase.predict(fluctuated_mean_machine), y)
     @test initial_risk >= fluct_risk || isapprox(initial_risk, fluct_risk, atol=atol)
 end

--- a/test/helper_fns.jl
+++ b/test/helper_fns.jl
@@ -24,8 +24,12 @@ increase risk more than tol
 function test_fluct_decreases_risk(cache; atol=1e-6)
     fluctuated_mean_machine = cache[:targeted_factors].outcome_mean.machine
     initial_mean_machine = fluctuated_mean_machine.model.initial_factors.outcome_mean.machine
+    X = fluctuated_mean_machine.data[1]
     y = fluctuated_mean_machine.data[2]
-    initial_risk = risk(MLJBase.predict(initial_mean_machine), y)
+    # Predict the initial mean on the fluctuation's rows rather than the initial machine's own
+    # training rows: under IPCW the outcome mean is fit on complete cases only, so its training
+    # set is a strict subset of the fluctuation rows. Outside IPCW the two coincide.
+    initial_risk = risk(MLJBase.predict(initial_mean_machine, X), y)
     fluct_risk = risk(MLJBase.predict(fluctuated_mean_machine), y)
     @test initial_risk >= fluct_risk || isapprox(initial_risk, fluct_risk, atol=atol)
 end

--- a/test/missing_management.jl
+++ b/test/missing_management.jl
@@ -49,10 +49,10 @@ end
 @testset "Test estimation with missing values and ordered factor treatment" begin
     dataset = dataset_with_missing_and_ordered_treatment(;n=1000)
     Ψ = ATE(
-        outcome=:Y, 
+        outcome=:Y,
         treatment_values=(T=(case=1, control=0),),
         treatment_confounders=(T=[:W],))
-    models = Dict(:Y => with_encoder(LinearRegressor()), :T => LogisticClassifier(lambda=0))
+    models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
     tmle = Tmle(models=models, machine_cache=true)
     tmle_result, cache = tmle(Ψ, dataset; verbosity=0)
     test_coverage(tmle_result, 1)

--- a/test/missing_management.jl
+++ b/test/missing_management.jl
@@ -50,7 +50,7 @@ end
 @testset "Test estimation with missing values and ordered factor treatment" begin
     dataset = dataset_with_missing_and_ordered_treatment(;n=1000)
     Ψ = ATE(
-        outcome=:Y,
+        outcome=:Y, 
         treatment_values=(T=(case=1, control=0),),
         treatment_confounders=(T=[:W],))
     models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
@@ -58,42 +58,6 @@ end
     tmle_result, cache = tmle(Ψ, dataset; verbosity=0)
     test_coverage(tmle_result, 1)
     test_fluct_decreases_risk(cache)
-end
-
-function dataset_with_missing_covariates(;n=1000)
-    rng = StableRNG(456)
-    W = rand(rng, n)
-    T = rand(rng, [0, 1], n)
-    Y = T + 3W + randn(rng, n)
-    dataset = DataFrame(W = W, T = categorical(T, ordered=true), Y = Y)
-    allowmissing!(dataset, [:W, :T])
-    dataset.W[1:5] .= missing
-    dataset.T[6:10] .= missing
-    return dataset
-end
-
-@testset "Test CV-TMLE with missing covariate values" begin
-    dataset = dataset_with_missing_covariates(;n=1000)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],))
-    models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
-    tmle = Tmle(models=models, resampling=CV(nfolds=3))
-    tmle_result, _ = tmle(Ψ, dataset; verbosity=0)
-    test_coverage(tmle_result, 1)
-end
-
-@testset "Test CV-OSE with missing covariate values" begin
-    dataset = dataset_with_missing_covariates(;n=1000)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],))
-    models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
-    ose = Ose(models=models, resampling=CV(nfolds=3))
-    ose_result, _ = ose(Ψ, dataset; verbosity=0)
-    test_coverage(ose_result, 1)
 end
 
 end

--- a/test/missing_management.jl
+++ b/test/missing_management.jl
@@ -3,6 +3,7 @@ module TestMissingValues
 using Test
 using StableRNGs
 using Random
+using MLJBase
 using MLJLinearModels
 using TMLE
 using CategoricalArrays
@@ -57,6 +58,42 @@ end
     tmle_result, cache = tmle(Ψ, dataset; verbosity=0)
     test_coverage(tmle_result, 1)
     test_fluct_decreases_risk(cache)
+end
+
+function dataset_with_missing_covariates(;n=1000)
+    rng = StableRNG(456)
+    W = rand(rng, n)
+    T = rand(rng, [0, 1], n)
+    Y = T + 3W + randn(rng, n)
+    dataset = DataFrame(W = W, T = categorical(T, ordered=true), Y = Y)
+    allowmissing!(dataset, [:W, :T])
+    dataset.W[1:5] .= missing
+    dataset.T[6:10] .= missing
+    return dataset
+end
+
+@testset "Test CV-TMLE with missing covariate values" begin
+    dataset = dataset_with_missing_covariates(;n=1000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],))
+    models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
+    tmle = Tmle(models=models, resampling=CV(nfolds=3))
+    tmle_result, _ = tmle(Ψ, dataset; verbosity=0)
+    test_coverage(tmle_result, 1)
+end
+
+@testset "Test CV-OSE with missing covariate values" begin
+    dataset = dataset_with_missing_covariates(;n=1000)
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],))
+    models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
+    ose = Ose(models=models, resampling=CV(nfolds=3))
+    ose_result, _ = ose(Ψ, dataset; verbosity=0)
+    test_coverage(ose_result, 1)
 end
 
 end

--- a/test/missing_management.jl
+++ b/test/missing_management.jl
@@ -54,7 +54,7 @@ end
         treatment_confounders=(T=[:W],))
     models = Dict(:Y => with_encoder(LinearRegressor()),
         :T => with_encoder(LogisticClassifier(lambda=0)),
-        Symbol("Δ_Y") => with_encoder(LinearBinaryClassifier()))
+        Symbol("Δ_Y") => with_encoder(TMLE.LinearBinaryClassifier()))
     tmle = Tmle(models=models, machine_cache=true)
     tmle_result, cache = tmle(Ψ, dataset; verbosity=0)
     test_coverage(tmle_result, 1)

--- a/test/missing_management.jl
+++ b/test/missing_management.jl
@@ -3,7 +3,6 @@ module TestMissingValues
 using Test
 using StableRNGs
 using Random
-using MLJBase
 using MLJLinearModels
 using TMLE
 using CategoricalArrays
@@ -53,7 +52,9 @@ end
         outcome=:Y, 
         treatment_values=(T=(case=1, control=0),),
         treatment_confounders=(T=[:W],))
-    models = default_models(Y=LinearRegressor(), T=LogisticClassifier(lambda=0))
+    models = Dict(:Y => with_encoder(LinearRegressor()),
+        :T => with_encoder(LogisticClassifier(lambda=0)),
+        Symbol("Δ_Y") => with_encoder(LinearBinaryClassifier()))
     tmle = Tmle(models=models, machine_cache=true)
     tmle_result, cache = tmle(Ψ, dataset; verbosity=0)
     test_coverage(tmle_result, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ TEST_DIR = joinpath(pkgdir(TMLE), "test")
     @test include(joinpath(TEST_DIR, "counterfactual_mean_based/3points_interactions.jl"))
     @test include(joinpath(TEST_DIR, "counterfactual_mean_based/collaborative_template.jl"))
     @test include(joinpath(TEST_DIR, "counterfactual_mean_based/covariate_based_strategies.jl"))
+    @test include(joinpath(TEST_DIR, "counterfactual_mean_based/ipcw.jl"))
     
     # Test Extensions
     if VERSION >= v"1.9"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -201,11 +201,11 @@ end
     )
     # The treatment levels correctly appear in the dataset
     dataset = DataFrame(Y=rand(10), T=rand(0:1, 10), W=rand(10))
-    @test TMLE.check_inputs(Ψ, dataset, nothing) isa Any
+    @test TMLE.check_inputs(Ψ, dataset, nothing, false) isa Any
     # The treatment levels do not appear in the dataset
     dataset = DataFrame(Y=rand(10), T=rand(2:3, 10), W=rand(10))
     msg = "The treatment variable T's, 'control' level: '0' in Ψ does not match any level in the dataset: [2, 3]"
-    @test_throws ArgumentError(msg) TMLE.check_inputs(Ψ, dataset, nothing)
+    @test_throws ArgumentError(msg) TMLE.check_inputs(Ψ, dataset, nothing, false)
 
     # Check with prevalence
     prevalence = 0.1
@@ -220,14 +220,14 @@ end
         T = categorical([1, 1, 0, 1, 0, 2, 2]),
         W = rand(7)
     )
-    @test_throws ArgumentError("Outcome column must be binary when prevalence is specified.") TMLE.check_inputs(Ψ, dataset, prevalence)
+    @test_throws ArgumentError("Outcome column must be binary when prevalence is specified.") TMLE.check_inputs(Ψ, dataset, prevalence, false)
     ## The number of controls must be larger than the number of cases
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0, 1, 1, 0]),
         T = categorical([1, 1, 0, 1, 0, 2, 2]),
         W = rand(7)
     )
-    @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence)
+    @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence, false)
 end
 
 @testset "Test get_initial_dataset" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -265,6 +265,26 @@ end
     @test fluctuation_dataset.W === dataset.W
 end
 
+@testset "Test choose_initial_dataset" begin
+    src_dataset = "src_dataset"
+    fluctuation_dataset = "fluctuation_dataset"
+    @test src_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=nothing, 
+        prevalence=nothing
+    )
+    @test fluctuation_dataset ===TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=nothing, 
+        prevalence=0.1
+    )
+    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=[], 
+        prevalence=nothing
+    )
+    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
+        train_validation_indices=[], 
+        prevalence=0.1
+    )
+end
 @testset "Test get_ipcw_fluctuation_dataset" begin
     # IPCW: keeps covariate-complete rows, coalesces missing Y to 0
     n = 10

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -263,7 +263,6 @@ end
     @test fluctuation_dataset.Y === dataset.Y
     @test fluctuation_dataset.T === dataset.T
     @test fluctuation_dataset.W === dataset.W
-
 end
 
 @testset "Test get_ipcw_fluctuation_dataset" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -264,6 +264,9 @@ end
     @test fluctuation_dataset.T === dataset.T
     @test fluctuation_dataset.W === dataset.W
 
+end
+
+@testset "Test get_ipcw_fluctuation_dataset" begin
     # IPCW: keeps covariate-complete rows, coalesces missing Y to 0
     n = 10
     dataset_ipcw = DataFrame(

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -230,7 +230,7 @@ end
     @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence)
 end
 
-@testset "Test get_evaluation_dataset" begin
+@testset "Test get_fluctuation_dataset" begin
     # Non-IPCW: missing values relevant to the estimation process are filtered
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0, 0, 0, 0, 0]),
@@ -243,13 +243,13 @@ end
         treatment_confounders=[:W]
     )
     relevant_factors = TMLE.get_relevant_factors(Ψ)
-    eval_data = TMLE.get_evaluation_dataset(dataset, relevant_factors)
+    eval_data = TMLE.get_fluctuation_dataset(dataset, relevant_factors)
     @test eval_data == dataset[Not([7]), :]
 
     # Non-IPCW with prevalence: surplus controls are dropped
     prevalence = 0.1
     expected_log = (:info, "Dropping 1 control(s) to ensure equal number of controls per case (J=2). You can pre-drop these controls yourself to prevent this operation.")
-    eval_data = @test_logs expected_log TMLE.get_evaluation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity=1)
+    eval_data = @test_logs expected_log TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity=1)
     @test nrow(eval_data) == 6
 
     # Non-IPCW no-op case: no missing, integer controls per case
@@ -258,7 +258,7 @@ end
         T = categorical([1, 1, 0, 1]),
         W = rand(4)
     )
-    eval_data = TMLE.get_evaluation_dataset(dataset, relevant_factors; prevalence=prevalence)
+    eval_data = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
     @test eval_data.Y === dataset.Y
     @test eval_data.T === dataset.T
     @test eval_data.W === dataset.W
@@ -277,7 +277,7 @@ end
         ATE(outcome=:Y, treatment_values=(T=(case=1, control=0),), treatment_confounders=(T=[:W],));
         dataset=dataset_ipcw
     )
-    eval_data = TMLE.get_evaluation_dataset(dataset_ipcw, rf_ipcw)
+    eval_data = TMLE.get_fluctuation_dataset(dataset_ipcw, rf_ipcw)
     # All rows kept (no missing covariates)
     @test nrow(eval_data) == n
     # Missing Y coalesced to 0

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -230,7 +230,7 @@ end
     @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence)
 end
 
-@testset "Test get_fluctuation_dataset" begin
+@testset "Test get_initial_dataset" begin
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0, 0, 0, 0, 0]),
         T = categorical([1, 1, 0, 1, 0, 2, missing, 0]),
@@ -244,14 +244,14 @@ end
     relevant_factors = TMLE.get_relevant_factors(Ψ)
     # No prevalence: missing values relevant to the estimation process are filtered
     prevalence = nothing
-    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
-    @test fluctuation_dataset == dataset[Not([7]), :]
+    initial_dataset = TMLE.get_initial_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test initial_dataset == dataset[Not([7]), :]
     # Prevalence: the surplus of controls are dropped, 2 controls per case are inferred
     prevalence = 0.1
     expected_log = (:info, "Dropping 1 control(s) to ensure equal number of controls per case (J=2). You can pre-drop these controls yourself to prevent this operation.")
-    fluctuation_dataset = @test_logs expected_log TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity = 1)
-    @test nrow(fluctuation_dataset) == 6
-    # If no missing values are present and the number of controls per case is an integer, 
+    initial_dataset = @test_logs expected_log TMLE.get_initial_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity = 1)
+    @test nrow(initial_dataset) == 6
+    # If no missing values are present and the number of controls per case is an integer,
     # these operations are no-ops, the dataframe will not be === because of column selection
     # but each column is ===
     dataset = DataFrame(
@@ -259,34 +259,14 @@ end
         T = categorical([1, 1, 0, 1]),
         W = rand(4)
     )
-    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
-    @test fluctuation_dataset.Y === dataset.Y
-    @test fluctuation_dataset.T === dataset.T
-    @test fluctuation_dataset.W === dataset.W
+    initial_dataset = TMLE.get_initial_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test initial_dataset.Y === dataset.Y
+    @test initial_dataset.T === dataset.T
+    @test initial_dataset.W === dataset.W
 end
 
-@testset "Test choose_initial_dataset" begin
-    src_dataset = "src_dataset"
-    fluctuation_dataset = "fluctuation_dataset"
-    @test src_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=nothing, 
-        prevalence=nothing
-    )
-    @test fluctuation_dataset ===TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=nothing, 
-        prevalence=0.1
-    )
-    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=[], 
-        prevalence=nothing
-    )
-    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=[], 
-        prevalence=0.1
-    )
-end
-@testset "Test get_ipcw_fluctuation_dataset" begin
-    # IPCW: keeps covariate-complete rows, coalesces missing Y to 0
+@testset "Test get_fluctuation_dataset (IPCW coalescing)" begin
+    # IPCW: initial dataset keeps missing Y; the fluctuation dataset coalesces it to 0
     n = 10
     dataset_ipcw = DataFrame(
         W = randn(n),
@@ -295,21 +275,28 @@ end
     )
     dataset_ipcw.Y[3] = missing
     dataset_ipcw.Y[7] = missing
-    TMLE.add_censoring_indicator!(dataset_ipcw, :Y)
+    dataset_ipcw = TMLE.add_censoring_indicator(dataset_ipcw, :Y)
     rf_ipcw = TMLE.get_relevant_factors(
         ATE(outcome=:Y, treatment_values=(T=(case=1, control=0),), treatment_confounders=(T=[:W],));
-        dataset=dataset_ipcw
+        ipcw=true
     )
-    eval_data = TMLE.get_fluctuation_dataset(dataset_ipcw, rf_ipcw)
-    # All rows kept (no missing covariates)
+    # Initial dataset: all rows kept (no missing covariates), missing Y preserved
+    initial_data = TMLE.get_initial_dataset(dataset_ipcw, rf_ipcw)
+    @test nrow(initial_data) == n
+    @test ismissing(initial_data.Y[3]) && ismissing(initial_data.Y[7])
+    # Fluctuation dataset: same rows, missing Y coalesced to 0
+    eval_data = TMLE.get_fluctuation_dataset(initial_data, rf_ipcw)
     @test nrow(eval_data) == n
-    # Missing Y coalesced to 0
     @test eval_data.Y[3] == 0.0
     @test eval_data.Y[7] == 0.0
+    # The indicator is retained for the IPCW clever covariate used by the fluctuation.
+    @test eval_data[!, :Δ_Y] == initial_data[!, :Δ_Y]
     # Non-missing Y preserved
     @test eval_data.Y[1] == dataset_ipcw.Y[1]
     # No missing types remain
     @test !any(TMLE.ismissingtype(eltype(c)) for c in eachcol(eval_data))
+    # Initial dataset is not mutated
+    @test ismissing(initial_data.Y[3])
 end
 
 end;

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -231,7 +231,6 @@ end
 end
 
 @testset "Test get_fluctuation_dataset" begin
-    # Non-IPCW: missing values relevant to the estimation process are filtered
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0, 0, 0, 0, 0]),
         T = categorical([1, 1, 0, 1, 0, 2, missing, 0]),
@@ -243,25 +242,27 @@ end
         treatment_confounders=[:W]
     )
     relevant_factors = TMLE.get_relevant_factors(Ψ)
-    eval_data = TMLE.get_fluctuation_dataset(dataset, relevant_factors)
-    @test eval_data == dataset[Not([7]), :]
-
-    # Non-IPCW with prevalence: surplus controls are dropped
+    # No prevalence: missing values relevant to the estimation process are filtered
+    prevalence = nothing
+    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test fluctuation_dataset == dataset[Not([7]), :]
+    # Prevalence: the surplus of controls are dropped, 2 controls per case are inferred
     prevalence = 0.1
     expected_log = (:info, "Dropping 1 control(s) to ensure equal number of controls per case (J=2). You can pre-drop these controls yourself to prevent this operation.")
-    eval_data = @test_logs expected_log TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity=1)
-    @test nrow(eval_data) == 6
-
-    # Non-IPCW no-op case: no missing, integer controls per case
+    fluctuation_dataset = @test_logs expected_log TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity = 1)
+    @test nrow(fluctuation_dataset) == 6
+    # If no missing values are present and the number of controls per case is an integer, 
+    # these operations are no-ops, the dataframe will not be === because of column selection
+    # but each column is ===
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0]),
         T = categorical([1, 1, 0, 1]),
         W = rand(4)
     )
-    eval_data = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
-    @test eval_data.Y === dataset.Y
-    @test eval_data.T === dataset.T
-    @test eval_data.W === dataset.W
+    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test fluctuation_dataset.Y === dataset.Y
+    @test fluctuation_dataset.T === dataset.T
+    @test fluctuation_dataset.W === dataset.W
 
     # IPCW: keeps covariate-complete rows, coalesces missing Y to 0
     n = 10

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -230,7 +230,8 @@ end
     @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence)
 end
 
-@testset "Test get_fluctuation_dataset" begin
+@testset "Test get_evaluation_dataset" begin
+    # Non-IPCW: missing values relevant to the estimation process are filtered
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0, 0, 0, 0, 0]),
         T = categorical([1, 1, 0, 1, 0, 2, missing, 0]),
@@ -242,48 +243,50 @@ end
         treatment_confounders=[:W]
     )
     relevant_factors = TMLE.get_relevant_factors(Ψ)
-    # No prevalence: missing values relevant to the estimation process are filtered
-    prevalence = nothing
-    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
-    @test fluctuation_dataset == dataset[Not([7]), :]
-    # Prevalence: the surplus of controls are dropped, 2 controls per case are inferred
+    eval_data = TMLE.get_evaluation_dataset(dataset, relevant_factors)
+    @test eval_data == dataset[Not([7]), :]
+
+    # Non-IPCW with prevalence: surplus controls are dropped
     prevalence = 0.1
     expected_log = (:info, "Dropping 1 control(s) to ensure equal number of controls per case (J=2). You can pre-drop these controls yourself to prevent this operation.")
-    fluctuation_dataset = @test_logs expected_log TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity = 1)
-    @test nrow(fluctuation_dataset) == 6
-    # If no missing values are present and the number of controls per case is an integer, 
-    # these operations are no-ops, the dataframe will not be === because of column selection
-    # but each column is ===
+    eval_data = @test_logs expected_log TMLE.get_evaluation_dataset(dataset, relevant_factors; prevalence=prevalence, verbosity=1)
+    @test nrow(eval_data) == 6
+
+    # Non-IPCW no-op case: no missing, integer controls per case
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0]),
         T = categorical([1, 1, 0, 1]),
         W = rand(4)
     )
-    fluctuation_dataset = TMLE.get_fluctuation_dataset(dataset, relevant_factors; prevalence=prevalence)
-    @test fluctuation_dataset.Y === dataset.Y
-    @test fluctuation_dataset.T === dataset.T
-    @test fluctuation_dataset.W === dataset.W
-end
+    eval_data = TMLE.get_evaluation_dataset(dataset, relevant_factors; prevalence=prevalence)
+    @test eval_data.Y === dataset.Y
+    @test eval_data.T === dataset.T
+    @test eval_data.W === dataset.W
 
-@testset "Test choose_initial_dataset" begin
-    src_dataset = "src_dataset"
-    fluctuation_dataset = "fluctuation_dataset"
-    @test src_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=nothing, 
-        prevalence=nothing
+    # IPCW: keeps covariate-complete rows, coalesces missing Y to 0
+    n = 10
+    dataset_ipcw = DataFrame(
+        W = randn(n),
+        T = categorical(rand(0:1, n)),
+        Y = Vector{Union{Missing, Float64}}(randn(n)),
     )
-    @test fluctuation_dataset ===TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=nothing, 
-        prevalence=0.1
+    dataset_ipcw.Y[3] = missing
+    dataset_ipcw.Y[7] = missing
+    TMLE.add_censoring_indicator!(dataset_ipcw, :Y)
+    rf_ipcw = TMLE.get_relevant_factors(
+        ATE(outcome=:Y, treatment_values=(T=(case=1, control=0),), treatment_confounders=(T=[:W],));
+        dataset=dataset_ipcw
     )
-    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=[], 
-        prevalence=nothing
-    )
-    @test fluctuation_dataset === TMLE.choose_initial_dataset(src_dataset, fluctuation_dataset;
-        train_validation_indices=[], 
-        prevalence=0.1
-    )
+    eval_data = TMLE.get_evaluation_dataset(dataset_ipcw, rf_ipcw)
+    # All rows kept (no missing covariates)
+    @test nrow(eval_data) == n
+    # Missing Y coalesced to 0
+    @test eval_data.Y[3] == 0.0
+    @test eval_data.Y[7] == 0.0
+    # Non-missing Y preserved
+    @test eval_data.Y[1] == dataset_ipcw.Y[1]
+    # No missing types remain
+    @test !any(TMLE.ismissingtype(eltype(c)) for c in eachcol(eval_data))
 end
 
 end;


### PR DESCRIPTION
# IPCW for Missing Outcomes — PR Summary

Closes #150 

## Overview

This PR adds **Inverse Probability of Censoring Weighting (IPCW)** to handle missing outcome values in both TMLE and OSE estimators. When the outcome column contains `missing` values, a censoring model is automatically fit and used to re-weight the efficient influence curve, correcting for outcome missing-ness under a Missing at Random (MAR) assumption.

Although this PR (both the code and this text) was largely Claude generated, all the code has been manually reviewed and cleaned by me (a human).



## Inverse Probability of Censoring Weighting

Say we have random variables $Y, \Delta, T, W$ where $Y$ are outcomes, $\Delta$ is whether or not $Y$ was observed, $T$ is whether it was treated and $W$ are observed covariates. We're generally interested in estimating a counterfactual mean like $\psi = E[Y(\Delta = 1, T = 1)]$: the expected outcome if we had observed and treated everyone. This is really no different from the counterfactual mean TMLE.jl already estimates: our intervention is just on two variables $\Delta$ and $T$ instead of one. The standard influence function for this estimand is

$$
\frac{T \Delta}{p(T, \Delta | W)}(Y - \mu(W)) + \mu(W) - \psi
$$

We can decompose $p(T, \Delta | W) = p(\Delta | T, W)p( T | W)$. So we end up multiplying our one step estimators and clever covariates by $\frac{1}{p(\Delta | T, W)}$, the inverse probability of censoring. 


Specifically, this PR does the following:

When the outcome column's `eltype` includes `Missing`, IPCW activates automatically:

- A **censoring indicator** `Δ_Y` gets added to the dataset (1 = observed, 0 = missing).
- A **censoring model** gets fit as an additional nuisance function alongside Q (outcome mean) and G (propensity score). By default it uses the same covariates as Q and a `LinearBinaryClassifier`.
- The **influence curve** is reweighted by `Δ/π`. For rows where the outcome is missing, `Δ=0` zeroes out the IC contribution. For observed rows, `1/π` upweights those that were less likely to be observed, correcting the MAR bias.

No user configuration is needed. Custom censoring models can be passed via `default_models(C=YourModel())` or by keying the model dict with the censoring indicator name (e.g., `Symbol("Δ_Y") => your_model`).



## Key Changes

1. **New censoring score in the estimand structure**: `CMRelevantFactors` gains an optional `censoring_score` field. `get_relevant_factors` populates it automatically when missing outcomes are detected.

2. **New nuisance estimator**: `estimate_censoring_score` fits the censoring model. Model lookup falls back through the censoring indicator name → `:C_default` → `:G_default`.

3. **IPCW reweighting in the gradient**: `∇YX` multiplies by `Δ/π` when a censoring score is present. For TMLE, the fluctuation step's observation weights are also multiplied by `Δ/π`.

4. **Restructured dataset flow**: The old approach applied a blanket `nomissing` filter early, dropping all rows with any missing value (including missing Y). This made IPCW weights trivially 1. The new approach passes the original dataset to nuisance estimators in vanilla mode — each estimator filters on its own variables internally — and builds a separate fluctuation dataset where missing Y is coalesced to 0 (not dropped) so IPCW weights are non-trivial.

5. **Fold-index alignment fix**: CV fold indices are now generated from the post-filtered fluctuation dataset rather than the original dataset, fixing a pre-existing bug where indices could reference the wrong rows when covariates had missing values.

6. **IPCW+CV support**: In CV mode, the sample-split estimator now applies `dropmissing` per fold. Q correctly trains on complete cases within each fold while G and C train on all covariate-complete rows. The `fluctuation_dataset` (with Y coalesced to 0) is used for both nuisance fitting and evaluation — Q's internal `completecases` filtering ensures it only trains on observed outcomes.

   

---

## CV Fold-Index Alignment Bug Fix

Previously, fold indices were generated from the **original dataset** (via `get_train_validation_indices(resampling, Ψ, dataset)`), but nuisance estimators and the fluctuation step operated on a **filtered dataset** with missing-covariate rows removed. For example, if the original dataset had 1000 rows and 10 had missing covariates, the filtered dataset had 990 rows — but fold indices still referenced the 1000-row dataset (e.g., a fold might include index 997, which doesn't exist in the 990-row dataset, while index 500 in the original dataset maps to a different row in the filtered one).

This never surfaced because existing CV tests used datasets with no missing covariate values. With IPCW introducing more nuanced filtering (dropping covariate-missing rows while keeping outcome-missing rows), the alignment issue became more apparent.

**The fix**: `get_train_validation_indices` is now called on `fluctuation_dataset` (the post-filtering dataset) instead of the original `dataset`. Fold indices are generated from the same dataset that is used for fitting and evaluation, so they always align. New tests (`"Test CV-TMLE with missing covariate values"` and `"Test CV-OSE with missing covariate values"`) exercise this path.

---

## Late Filtering: Change in When Missing Values Are Removed

The old code applied a single blanket filter early — `get_fluctuation_dataset` called `nomissing(dataset, variables(relevant_factors))`, dropping all rows with any missing value across all relevant variables (including the outcome). Then `choose_initial_dataset` decided whether to pass this filtered dataset or the original to nuisance estimators:

- **Vanilla mode**: nuisance estimators received the original `dataset` and each called `nomissing` internally on their own variables.
- **CV/prevalence mode**: nuisance estimators received the pre-filtered `fluctuation_dataset`.

This early blanket filter was incompatible with IPCW. Dropping missing-Y rows before IPCW weights are computed makes the weights trivially 1 (every remaining row has Δ=1), reducing IPCW to a complete-case analysis.

**The new approach** builds a single `fluctuation_dataset` via `get_fluctuation_dataset`:

- **IPCW mode**: drops covariate-missing rows but *keeps* outcome-missing rows with Y coalesced to 0. This means IPCW weights are non-trivial (Δ=0 for censored rows, upweighted observed rows).
- **Non-IPCW mode**: behavior is identical to the old `get_fluctuation_dataset`.

When CV, prevalence, or IPCW is active, `fluctuation_dataset` is passed to nuisance estimators. In vanilla non-IPCW mode, the original `dataset` is passed instead. Each nuisance estimator calls `completecases` internally on its own variables, so Q trains on complete cases only, while G and C (whose variables don't include Y) train on all covariate-complete rows. No separate `fitting_dataset` is needed.
