### PR TITLE
Make `G` a NamedTuple for ipcw suggestion

### DIFF
--- a/src/counterfactual_mean_based/clever_covariate.jl
+++ b/src/counterfactual_mean_based/clever_covariate.jl
@@ -18,7 +18,7 @@ function truncate!(v::AbstractVector, ps_lowerbound::AbstractFloat)
     end
 end
 
-function balancing_weights(G, dataset; ps_lowerbound=1e-8)
+function balancing_weights(G::JointConditionalDistributionEstimate, dataset; ps_lowerbound=1e-8)
     jointlikelihood = ones(nrows(dataset))
     for Gᵢ ∈ G.components
         jointlikelihood .*= likelihood(Gᵢ, dataset)

--- a/src/counterfactual_mean_based/clever_covariate.jl
+++ b/src/counterfactual_mean_based/clever_covariate.jl
@@ -28,6 +28,22 @@ function balancing_weights(G::JointConditionalDistributionEstimate, dataset; ps_
 end
 
 """
+    balancing_weights(G::Tuple, dataset; ps_lowerbound=1e-8)
+
+In the case where G contains both the propensity score and the censoring score, this function computes the balancing weights as the product of the two scores' likelihoods.
+"""
+function balancing_weights(G::Tuple, dataset; ps_lowerbound=1e-8)
+    propensity_score, censoring_score = G
+    weights = balancing_weights(propensity_score, dataset; ps_lowerbound=ps_lowerbound)
+    weights .*= compute_ipcw_weights(censoring_score, dataset; ps_lowerbound=ps_lowerbound)
+    return weights
+end
+
+retrieve_propensity_score(G::Tuple) = G[1]
+
+retrieve_propensity_score(G) = G
+
+"""
     clever_covariate_and_weights(
         Ψ::StatisticalCMCompositeEstimand, 
         Gs::Tuple{Vararg{ConditionalDistributionEstimate}}, 
@@ -55,16 +71,13 @@ function clever_covariate_and_weights(
     Ψ::StatisticalCMCompositeEstimand, 
     G, 
     dataset; 
-    censoring_score=nothing,
     ps_lowerbound=1e-8, 
     weighted_fluctuation=false
     )
     # Compute the indicator values
-    T = selectcols(dataset, (p.estimand.outcome for p in G.components))
+    T = selectcols(dataset, (p.estimand.outcome for p in retrieve_propensity_score(G).components))
     indic_vals = indicator_values(indicator_fns(Ψ), T)
     weights = balancing_weights(G, dataset; ps_lowerbound=ps_lowerbound)
-    ipcw = compute_ipcw_weights(censoring_score, dataset; ps_lowerbound=ps_lowerbound)
-    ipcw != nothing && (weights .*= ipcw)
     if weighted_fluctuation
         return indic_vals, weights
     end

--- a/src/counterfactual_mean_based/clever_covariate.jl
+++ b/src/counterfactual_mean_based/clever_covariate.jl
@@ -18,38 +18,30 @@ function truncate!(v::AbstractVector, ps_lowerbound::AbstractFloat)
     end
 end
 
-function balancing_weights(G::JointConditionalDistributionEstimate, dataset; ps_lowerbound=1e-8)
+"""
+    balancing_weights(G::NamedTuple, dataset; ps_lowerbound=1e-8)
+
+G always carries a `propensity_score` and a (possibly `nothing`) `censoring_score`. When the
+latter is present, the inverse probability of censoring weights are folded in.
+"""
+function balancing_weights(G::NamedTuple, dataset; ps_lowerbound=1e-8)
     jointlikelihood = ones(nrows(dataset))
-    for Gᵢ ∈ G.components
+    for Gᵢ ∈ G.propensity_score.components
         jointlikelihood .*= likelihood(Gᵢ, dataset)
     end
     truncate!(jointlikelihood, ps_lowerbound)
-    return 1. ./ jointlikelihood
-end
-
-"""
-    balancing_weights(G::Tuple, dataset; ps_lowerbound=1e-8)
-
-In the case where G contains both the propensity score and the censoring score, this function computes the balancing weights as the product of the two scores' likelihoods.
-"""
-function balancing_weights(G::Tuple, dataset; ps_lowerbound=1e-8)
-    propensity_score, censoring_score = G
-    weights = balancing_weights(propensity_score, dataset; ps_lowerbound=ps_lowerbound)
-    weights .*= compute_ipcw_weights(censoring_score, dataset; ps_lowerbound=ps_lowerbound)
+    weights = 1. ./ jointlikelihood
+    ipcw = compute_ipcw_weights(G.censoring_score, dataset; ps_lowerbound=ps_lowerbound)
+    ipcw === nothing || (weights .*= ipcw)
     return weights
 end
-
-retrieve_propensity_score(G::Tuple) = G[1]
-
-retrieve_propensity_score(G) = G
 
 """
     clever_covariate_and_weights(
         Ψ::StatisticalCMCompositeEstimand, 
-        Gs::Tuple{Vararg{ConditionalDistributionEstimate}}, 
+        G::NamedTuple, 
         dataset; 
         ps_lowerbound=1e-8, 
-        censoring_score=nothing,
         weighted_fluctuation=false
     )
 
@@ -69,13 +61,13 @@ where SpecialIndicator(t) is defined in `indicator_fns`.
 """
 function clever_covariate_and_weights(
     Ψ::StatisticalCMCompositeEstimand, 
-    G, 
+    G::NamedTuple, 
     dataset; 
     ps_lowerbound=1e-8, 
     weighted_fluctuation=false
     )
     # Compute the indicator values
-    T = selectcols(dataset, (p.estimand.outcome for p in retrieve_propensity_score(G).components))
+    T = selectcols(dataset, (p.estimand.outcome for p in G.propensity_score.components))
     indic_vals = indicator_values(indicator_fns(Ψ), T)
     weights = balancing_weights(G, dataset; ps_lowerbound=ps_lowerbound)
     if weighted_fluctuation

--- a/src/counterfactual_mean_based/estimates.jl
+++ b/src/counterfactual_mean_based/estimates.jl
@@ -9,7 +9,7 @@ for counterfactual mean based estimands' relevant factors.
 struct MLCMRelevantFactors <: Estimate
     estimand::CMRelevantFactors
     outcome_mean::ConditionalDistributionEstimate
-    propensity_score
+    propensity_score:: JointConditionalDistributionEstimate
     censoring_score::Union{Nothing, ConditionalDistributionEstimate}
 end
 

--- a/src/counterfactual_mean_based/estimates.jl
+++ b/src/counterfactual_mean_based/estimates.jl
@@ -17,9 +17,14 @@ end
 MLCMRelevantFactors(estimand, outcome_mean, propensity_score) =
     MLCMRelevantFactors(estimand, outcome_mean, propensity_score, nothing)
 
-getG(factors::MLCMRelevantFactors{Nothing}) = factors.propensity_score
+"""
+    getG(factors::MLCMRelevantFactors)
 
-getG(factors::MLCMRelevantFactors{<:ConditionalDistributionEstimate}) = (factors.propensity_score, factors.censoring_score)
+The treatment mechanism used by the clever covariate: always a named tuple, whose
+`censoring_score` is `nothing` outside IPCW mode.
+"""
+getG(factors::MLCMRelevantFactors) =
+    (propensity_score=factors.propensity_score, censoring_score=factors.censoring_score)
 
 """
     align_to_rows(factors::MLCMRelevantFactors, keep::Vector{Int})

--- a/src/counterfactual_mean_based/estimates.jl
+++ b/src/counterfactual_mean_based/estimates.jl
@@ -5,16 +5,21 @@
 """
 Holds a Sample Split Machine Learning set of estimates (outcome mean, propensity score) 
 for counterfactual mean based estimands' relevant factors.
+
 """
-struct MLCMRelevantFactors <: Estimate
+struct MLCMRelevantFactors{C <: Union{Nothing, <:ConditionalDistributionEstimate}} <: Estimate
     estimand::CMRelevantFactors
     outcome_mean::ConditionalDistributionEstimate
     propensity_score:: JointConditionalDistributionEstimate
-    censoring_score::Union{Nothing, ConditionalDistributionEstimate}
+    censoring_score::C
 end
 
 MLCMRelevantFactors(estimand, outcome_mean, propensity_score) =
     MLCMRelevantFactors(estimand, outcome_mean, propensity_score, nothing)
+
+getG(factors::MLCMRelevantFactors{Nothing}) = factors.propensity_score
+
+getG(factors::MLCMRelevantFactors{<:ConditionalDistributionEstimate}) = (factors.propensity_score, factors.censoring_score)
 
 """
     align_to_rows(factors::MLCMRelevantFactors, keep::Vector{Int})

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -126,11 +126,9 @@ end
 function (tmle::Tmle)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), verbosity=1, acceleration=CPU1())
     # Detect missing outcomes
     ipcw = tmle.ipcw & has_missing_outcomes(dataset, Ψ.outcome)
-    if ipcw && tmle.prevalence !== nothing
-        throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
-    end
+
     # Check if the inputs are suitable for the specified estimand
-    check_inputs(Ψ, dataset, tmle.prevalence)
+    check_inputs(Ψ, dataset, tmle.prevalence, ipcw)
     # Add censoring indicator if needed
     if ipcw
         dataset = add_censoring_indicator(dataset, Ψ.outcome)
@@ -264,7 +262,7 @@ function (ose::Ose)(Ψ::StatisticalCMCompositeEstimand, dataset; cache=Dict(), v
         throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
     end
     # Check the estimand against the dataset
-    check_inputs(Ψ, dataset, ose.prevalence)
+    check_inputs(Ψ, dataset, ose.prevalence, ipcw)
     # Add censoring indicator if needed
     if ipcw
         dataset = add_censoring_indicator(dataset, Ψ.outcome)

--- a/src/counterfactual_mean_based/estimators.jl
+++ b/src/counterfactual_mean_based/estimators.jl
@@ -313,9 +313,9 @@ end
 
 function gradient_and_estimate(::Ose, Ψ, factors, dataset, prevalence_weights; ps_lowerbound=1e-8)
     Q = factors.outcome_mean
-    G = factors.propensity_score
+    G = getG(factors)
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
-    gradient_Y_X = ∇YX(Ψ, Q, G, dataset; censoring_score=factors.censoring_score, ps_lowerbound=ps_lowerbound)
+    gradient_Y_X = ∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound)
     y = float(dataset[!, Q.estimand.outcome])
     IC, Ψ̂ = gradient_and_estimate(ctf_agg, gradient_Y_X, y, prevalence_weights)
     IC_mean = mean(IC)

--- a/src/counterfactual_mean_based/fluctuation.jl
+++ b/src/counterfactual_mean_based/fluctuation.jl
@@ -12,6 +12,9 @@ end
 Fluctuation(Ψ, initial_factors; tol=nothing, max_iter=1, ps_lowerbound=1e-8, weighted=false, cache=false, prevalence_weights=nothing) =
     Fluctuation(Ψ, initial_factors, tol, max_iter, ps_lowerbound, weighted, cache, prevalence_weights)
 
+
+getG(model::Fluctuation) = getG(model.initial_factors)
+
 """
 The fluctuation reads the censoring indicator `Δ_Y` off the clever covariate (IPCW), so it must
 be kept in `X` even though it is not one of the outcome model's parents.
@@ -61,12 +64,11 @@ If prevalence weights are provided, they are applied to the weights and normaliz
 """
 function initialize_observed_cache(model, X, y)
     Q⁰ = model.initial_factors.outcome_mean
-    G⁰ = model.initial_factors.propensity_score
+    G⁰ = getG(model)
     H, w = clever_covariate_and_weights(
         model.Ψ, G⁰, X;
         ps_lowerbound=model.ps_lowerbound,
         weighted_fluctuation=model.weighted,
-        censoring_score=model.initial_factors.censoring_score
     )
     ŷ = MLJBase.predict(Q⁰, X)
     return Dict{Symbol, Any}(:H => H, :w => w, :ŷ => ŷ, :y => float(y))
@@ -85,7 +87,7 @@ These are used to evaluate the gradient and estimate
 """
 function initialize_counterfactual_cache(model, X)
     Q⁰ = model.initial_factors.outcome_mean
-    G⁰ = model.initial_factors.propensity_score
+    G⁰ = getG(model)
     Ψ = model.Ψ
     counterfactual_cache = (predictions=[], signs=[], covariates=[])
     Ttemplate = selectcols(X, treatments(Ψ))
@@ -318,7 +320,7 @@ Generates initial predictions and iteratively predicts from the fitted fluctuati
 """
 function MLJBase.predict(model::Fluctuation, machines, X) 
     covariate, _ = clever_covariate_and_weights(
-        model.Ψ, model.initial_factors.propensity_score, X;
+        model.Ψ, getG(model), X;
         ps_lowerbound=model.ps_lowerbound,
         weighted_fluctuation=model.weighted
     )

--- a/src/counterfactual_mean_based/gradient.jl
+++ b/src/counterfactual_mean_based/gradient.jl
@@ -52,9 +52,9 @@ Computes the projection of the gradient on the (Y | X) space.
 
 This part of the gradient is evaluated on the original dataset. All quantities have been precomputed and cached.
 """
-function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; censoring_score=nothing, ps_lowerbound=1e-8)
+function ∇YX(Ψ::StatisticalCMCompositeEstimand, Q, G, dataset; ps_lowerbound=1e-8)
     # Maybe can cache some results (H and E[Y|X]) to improve perf here
-    H, w = clever_covariate_and_weights(Ψ, G, dataset; censoring_score=censoring_score, ps_lowerbound=ps_lowerbound)
+    H, w = clever_covariate_and_weights(Ψ, G, dataset; ps_lowerbound=ps_lowerbound)
     y = float(dataset[!, Q.estimand.outcome])
     Ey = expected_value(Q, dataset)
     return ∇YX(H, y, Ey, w)
@@ -63,10 +63,10 @@ end
 
 function gradient_and_plugin_estimate(Ψ::StatisticalCMCompositeEstimand, factors, dataset; ps_lowerbound=1e-8)
     Q = factors.outcome_mean
-    G = factors.propensity_score
+    G = getG(factors)
     ctf_agg = counterfactual_aggregate(Ψ, Q, dataset)
     Ψ̂ = plugin_estimate(ctf_agg)
-    IC = ∇YX(Ψ, Q, G, dataset; censoring_score=factors.censoring_score, ps_lowerbound = ps_lowerbound) .+ ∇W(ctf_agg, Ψ̂)
+    IC = ∇YX(Ψ, Q, G, dataset; ps_lowerbound = ps_lowerbound) .+ ∇W(ctf_agg, Ψ̂)
     return IC, Ψ̂
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -340,9 +340,12 @@ with_encoder(model; encoder=ContinuousEncoder(drop_last=true, one_hot_ordered_fa
 
 Evaluate if the dataset is suitable for the estimand Ψ.
 """
-function check_inputs(Ψ, dataset, prevalence)
+function check_inputs(Ψ, dataset, prevalence, ipcw)
     check_treatment_levels(Ψ, dataset)
     !isnothing(prevalence) && ccw_check(dataset, Ψ.outcome)
+    if ipcw && prevalence !== nothing
+        throw(ArgumentError("IPCW (missing outcomes) is not yet supported with prevalence correction. The interaction between case-control weights and censoring weights requires a specialized influence function."))
+    end
 end
 
 """

--- a/test/counterfactual_mean_based/clever_covariate.jl
+++ b/test/counterfactual_mean_based/clever_covariate.jl
@@ -38,7 +38,7 @@ end
     )
     weighted_fluctuation = true
     ps_lowerbound = 1e-8
-    cov, w = TMLE.clever_covariate_and_weights(Ψ, propensity_score_estimate, dataset; 
+    cov, w = TMLE.clever_covariate_and_weights(Ψ, (propensity_score=propensity_score_estimate, censoring_score=nothing), dataset; 
         ps_lowerbound=ps_lowerbound, 
         weighted_fluctuation=weighted_fluctuation
     )
@@ -47,7 +47,7 @@ end
     @test w == [1.75, 3.5, 7.0, 1.75, 1.75, 3.5, 1.75]
 
     weighted_fluctuation = false
-    cov, w = TMLE.clever_covariate_and_weights(Ψ, propensity_score_estimate, dataset;
+    cov, w = TMLE.clever_covariate_and_weights(Ψ, (propensity_score=propensity_score_estimate, censoring_score=nothing), dataset;
         ps_lowerbound=ps_lowerbound,
         weighted_fluctuation=weighted_fluctuation
     )
@@ -83,7 +83,7 @@ end
     ps_lowerbound = 1e-8
     weighted_fluctuation = false
 
-    cov, w = TMLE.clever_covariate_and_weights(Ψ, propensity_score_estimate, dataset;
+    cov, w = TMLE.clever_covariate_and_weights(Ψ, (propensity_score=propensity_score_estimate, censoring_score=nothing), dataset;
         ps_lowerbound=ps_lowerbound,
         weighted_fluctuation=weighted_fluctuation
     )
@@ -128,7 +128,7 @@ end
         verbosity=0
     )
 
-    cov, w = TMLE.clever_covariate_and_weights(Ψ, propensity_score_estimate, dataset;
+    cov, w = TMLE.clever_covariate_and_weights(Ψ, (propensity_score=propensity_score_estimate, censoring_score=nothing), dataset;
         ps_lowerbound=ps_lowerbound, 
         weighted_fluctuation=weighted_fluctuation
     )

--- a/test/counterfactual_mean_based/estimators_and_estimates.jl
+++ b/test/counterfactual_mean_based/estimators_and_estimates.jl
@@ -50,7 +50,7 @@ end
     cache = Dict()
     η̂ₙ = @test_logs fit_log... match_mode=:any η̂(η, dataset; cache=cache, verbosity=1)
     @test η̂ₙ isa TMLE.MLCMRelevantFactors{Nothing}
-    @test TMLE.getG(η̂ₙ) === η̂ₙ.propensity_score
+    @test TMLE.getG(η̂ₙ) === (propensity_score=η̂ₙ.propensity_score, censoring_score=nothing)
     # Test both sub estimands have been fitted
     @test η̂ₙ.outcome_mean isa TMLE.MLConditionalDistribution
     @test fitted_params(η̂ₙ.outcome_mean.machine) isa NamedTuple
@@ -105,7 +105,7 @@ end
     η̂ = TMLE.CMRelevantFactorsEstimator(models=models)
     η̂ₙ = η̂(η, dataset;verbosity=0)
     @test η̂ₙ isa TMLE.MLCMRelevantFactors{TMLE.MLConditionalDistribution}
-    @test TMLE.getG(η̂ₙ) === (η̂ₙ.propensity_score, η̂ₙ.censoring_score)
+    @test TMLE.getG(η̂ₙ) === (propensity_score=η̂ₙ.propensity_score, censoring_score=η̂ₙ.censoring_score)
 end
 
 @testset "Test FitFailedError" begin

--- a/test/counterfactual_mean_based/estimators_and_estimates.jl
+++ b/test/counterfactual_mean_based/estimators_and_estimates.jl
@@ -29,7 +29,7 @@ end
     @test NAIVE(LinearRegressor()) isa TMLE.Plugin
 end
 
-@testset "Test CMRelevantFactorsEstimator" begin
+@testset "Test CMRelevantFactorsEstimator{Nothing}" begin
     dataset = make_dataset()
     # Estimand
     Q = TMLE.ConditionalDistribution(:Y, [:T₁, :W])
@@ -49,6 +49,8 @@ end
     )
     cache = Dict()
     η̂ₙ = @test_logs fit_log... match_mode=:any η̂(η, dataset; cache=cache, verbosity=1)
+    @test η̂ₙ isa TMLE.MLCMRelevantFactors{Nothing}
+    @test TMLE.getG(η̂ₙ) === η̂ₙ.propensity_score
     # Test both sub estimands have been fitted
     @test η̂ₙ.outcome_mean isa TMLE.MLConditionalDistribution
     @test fitted_params(η̂ₙ.outcome_mean.machine) isa NamedTuple
@@ -83,6 +85,27 @@ end
     ps_component = only(η̂ₙ.propensity_score.components)
     @test length(ps_component.machines) == 3
     @test η̂ₙ.outcome_mean.train_validation_indices == ps_component.train_validation_indices
+end
+
+@testset "Test CMRelevantFactorsEstimator{ConditionalDistributionEstimate}" begin
+    dataset = make_dataset()
+    dataset[!, :Y] = [w > 0.5 ? missing : y  for (y, w) in zip(dataset[!, :Y], dataset[!, :W])]
+    dataset[!, :ΔY] = categorical(.!ismissing.(dataset[!, :Y]))
+    # Estimand
+    Q = TMLE.ConditionalDistribution(:Y, [:T₁, :W])
+    G = (TMLE.ConditionalDistribution(:T₁, [:W]),)
+    C = TMLE.ConditionalDistribution(:ΔY , [:W])
+    η = TMLE.CMRelevantFactors(outcome_mean=Q, propensity_score=G, censoring_score=C)
+    # Estimator
+    models = Dict(
+        :Y  => with_encoder(LinearRegressor()), 
+        :T₁ => LogisticClassifier(),
+        :C_default => LogisticClassifier()
+    )
+    η̂ = TMLE.CMRelevantFactorsEstimator(models=models)
+    η̂ₙ = η̂(η, dataset;verbosity=0)
+    @test η̂ₙ isa TMLE.MLCMRelevantFactors{TMLE.MLConditionalDistribution}
+    @test TMLE.getG(η̂ₙ) === (η̂ₙ.propensity_score, η̂ₙ.censoring_score)
 end
 
 @testset "Test FitFailedError" begin

--- a/test/counterfactual_mean_based/gradient.jl
+++ b/test/counterfactual_mean_based/gradient.jl
@@ -45,7 +45,7 @@ end
     η̂ₙ = η̂(η, dataset, verbosity = 0)
     # Retrieve conditional distributions and fitted_params
     Q = η̂ₙ.outcome_mean
-    G = η̂ₙ.propensity_score
+    G = TMLE.getG(η̂ₙ)
     linear_model = fitted_params(Q.machine).deterministic_pipeline.linear_regressor
     intercept = linear_model.intercept
     coefs = Dict(linear_model.coefs)
@@ -54,7 +54,7 @@ end
     expected_ctf_agg = (intercept .+ coefs[:T] .+ dataset.W.*coefs[:W] .+ dataset.W.*coefs[:T_W]) .- (intercept .+ dataset.W.*coefs[:W])
     @test ctf_agg ≈ expected_ctf_agg atol=1e-10
     # Gradient Y|X
-    ps_machine = only(G.components).machine
+    ps_machine = only(G.propensity_score.components).machine
     H = 1 ./ pdf.(predict(ps_machine), dataset.T) .* [t == 1 ? 1. : -1. for t in dataset.T]
     expected_∇YX = H .* (dataset.Y .- predict(Q.machine))
     ∇YX = TMLE.∇YX(Ψ, Q, G, dataset; ps_lowerbound=ps_lowerbound)

--- a/test/counterfactual_mean_based/ipcw.jl
+++ b/test/counterfactual_mean_based/ipcw.jl
@@ -38,45 +38,6 @@ include(joinpath(dirname(dirname(pathof(TMLE))), "test", "helper_fns.jl"))
     @test TMLE.is_binary(df, :Δ_Y)
 end
 
-@testset "CMRelevantFactors with censoring_score" begin
-    om = TMLE.ConditionalDistribution(:Y, (:T, :W))
-    ps = TMLE.ConditionalDistribution(:T, (:W,))
-    cs = TMLE.ConditionalDistribution(:Δ_Y, (:T, :W))
-
-    # Without censoring
-    rf = TMLE.CMRelevantFactors(om, (ps,))
-    @test rf.censoring_score === nothing
-
-    # With censoring
-    rf_ipcw = TMLE.CMRelevantFactors(om, (ps,), cs)
-    @test rf_ipcw.censoring_score === cs
-    @test :Δ_Y ∈ TMLE.variables(rf_ipcw)
-
-    # Keyword constructor
-    rf_kw = TMLE.CMRelevantFactors(outcome_mean=om, propensity_score=(ps,), censoring_score=cs)
-    @test rf_kw == rf_ipcw
-end
-
-@testset "get_relevant_factors with IPCW" begin
-    # No dataset → no censoring
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
-    rf = TMLE.get_relevant_factors(Ψ)
-    @test rf.censoring_score === nothing
-
-    # ipcw=false → no censoring
-    rf = TMLE.get_relevant_factors(Ψ; ipcw=false)
-    @test rf.censoring_score === nothing
-
-    # ipcw=true → censoring activated
-    rf = TMLE.get_relevant_factors(Ψ; ipcw=true)
-    @test rf.censoring_score !== nothing
-    @test rf.censoring_score.outcome == :Δ_Y
-end
-
 """
 Generate a continuous outcome ATE problem with MAR missingness.
 Missingness depends on W (confounders) creating a MAR pattern.
@@ -104,7 +65,7 @@ function ate_with_mar_missingness(;n=2000)
     return dataset, ATE_true
 end
 
-@testset "IPCW OSE" begin
+@testset "IPCW OSE and TMLE" begin
     dataset, ATE_true = ate_with_mar_missingness(n=5000)
     Ψ = ATE(
         outcome=:Y,
@@ -114,15 +75,7 @@ end
     ose = Ose()
     result, _ = ose(Ψ, dataset; verbosity=0)
     test_coverage(result, ATE_true)
-end
 
-@testset "IPCW TMLE" begin
-    dataset, ATE_true = ate_with_mar_missingness(n=5000)
-    Ψ = ATE(
-        outcome=:Y,
-        treatment_values=(T=(case=1, control=0),),
-        treatment_confounders=(T=[:W],)
-    )
     tmle = Tmle()
     result, _ = tmle(Ψ, dataset; verbosity=0)
     test_coverage(result, ATE_true)

--- a/test/estimands.jl
+++ b/test/estimands.jl
@@ -30,6 +30,28 @@ end
     @test TMLE.variables(η) == (:Y, :T, :W, :T₁, :W₁, :T₂, :W₂₁, :W₂₂)
     # Test string representation
     @test TMLE.string_repr(η) == "Relevant Factors: \n- P₀(Y | T, W)\n- P₀(T₁ | W₁)\n- P₀(T₂ | W₂₁, W₂₂)"
+
+    η = TMLE.CMRelevantFactors(
+        outcome_mean=TMLE.ExpectedValue(:Y, [:T, :W]),
+        propensity_score=TMLE.ConditionalDistribution(:T, [:W]),
+        censoring_score=TMLE.ConditionalDistribution(:Δ_Y, (:T, :W))
+    )
+    @test :Δ_Y ∈ TMLE.variables(η)
+end
+
+@testset "get_relevant_factors with IPCW" begin
+    Ψ = ATE(
+        outcome=:Y,
+        treatment_values=(T=(case=1, control=0),),
+        treatment_confounders=(T=[:W],)
+    )
+    rf = TMLE.get_relevant_factors(Ψ)
+    @test rf.censoring_score === nothing
+
+    # ipcw=true → censoring activated
+    rf = TMLE.get_relevant_factors(Ψ; ipcw=true)
+    @test rf.censoring_score !== nothing
+    @test rf.censoring_score.outcome == :Δ_Y
 end
 
 @testset "Test JointEstimand and ComposedEstimand" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -201,11 +201,11 @@ end
     )
     # The treatment levels correctly appear in the dataset
     dataset = DataFrame(Y=rand(10), T=rand(0:1, 10), W=rand(10))
-    @test TMLE.check_inputs(Ψ, dataset, nothing) isa Any
+    @test TMLE.check_inputs(Ψ, dataset, nothing, false) isa Any
     # The treatment levels do not appear in the dataset
     dataset = DataFrame(Y=rand(10), T=rand(2:3, 10), W=rand(10))
     msg = "The treatment variable T's, 'control' level: '0' in Ψ does not match any level in the dataset: [2, 3]"
-    @test_throws ArgumentError(msg) TMLE.check_inputs(Ψ, dataset, nothing)
+    @test_throws ArgumentError(msg) TMLE.check_inputs(Ψ, dataset, nothing, false)
 
     # Check with prevalence
     prevalence = 0.1
@@ -220,14 +220,14 @@ end
         T = categorical([1, 1, 0, 1, 0, 2, 2]),
         W = rand(7)
     )
-    @test_throws ArgumentError("Outcome column must be binary when prevalence is specified.") TMLE.check_inputs(Ψ, dataset, prevalence)
+    @test_throws ArgumentError("Outcome column must be binary when prevalence is specified.") TMLE.check_inputs(Ψ, dataset, prevalence, false)
     ## The number of controls must be larger than the number of cases
     dataset = DataFrame(
         Y = categorical([1, 0, 1, 0, 1, 1, 0]),
         T = categorical([1, 1, 0, 1, 0, 2, 2]),
         W = rand(7)
     )
-    @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence)
+    @test_throws ArgumentError("The dataset must contain more controls (0) than cases (1) when prevalence is provided.") TMLE.check_inputs(Ψ, dataset, prevalence, false)
 end
 
 @testset "Test get_initial_dataset" begin


### PR DESCRIPTION
This is a proposal for making `G` have a fixed NamedTuple type instead of letting it take on different Tuple or JointConditionalDistributionEstimate types depending on context. 